### PR TITLE
Fix Crypto.com date parser. Add support for Crypto.com referral_gift transactions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ### Fixed
 - UserWarning: Must have at least one data row in in add_table().
 - AttributeError: 'module' object has no attribute 'UTC'. ([#27](https://github.com/BittyTax/BittyTax/issues/27))
+- Crypto.com parser: fix date parser.
 ### Added
 - Conversion tool: added parser for CGTCalculator.
 ### Changed
 - Hotbit parser: Negative fees are now set to zero.
 - Accounting tool: Drop buy/sell/fee transactions of zero quantity.
+- Crypto.com parser: Add support for referral_gift transaction type.
 
 ## Version [0.4.2] Beta (2020-10-30)
 ### Fixed
@@ -173,11 +175,11 @@
 - Conversion tool raises warning if 15-digit precision exceeded (Excel limit).
 - Conversion tool: added option to output in Recap import CSV format.
 ### Removed
-- Negative balance warning in a Section 104 holding. 
+- Negative balance warning in a Section 104 holding.
 - Logging removed from within config module.
 ### Changed
 - Logging is now initialised by each tool, instead of within the `config.py` module.
-- Conversion tool now outputs logging to `stderr` so it will be filtered when piping into `bittytax`. 
+- Conversion tool now outputs logging to `stderr` so it will be filtered when piping into `bittytax`.
 - The `pricedata.py` module has been renamed `valueasset.py`, and main function moved to new `price.py` module.
 - Package layout restructured, added subfolders for price and conv tools.
 - Refactored code for "all_handler" data parsers.

--- a/bittytax/conv/parsers/cryptocom.py
+++ b/bittytax/conv/parsers/cryptocom.py
@@ -12,7 +12,7 @@ WALLET = "Crypto.com"
 
 def parse_crypto_com(data_row, parser, _filename):
     in_row = data_row.in_row
-    data_row.timestamp = DataParser.parse_timestamp(in_row[0], dayfirst=True)
+    data_row.timestamp = DataParser.parse_timestamp(in_row[0])
 
     if in_row[9] == "crypto_transfer":
         if Decimal(in_row[3]) > 0:
@@ -65,7 +65,8 @@ def parse_crypto_com(data_row, parser, _filename):
                                                      sell_asset=in_row[2],
                                                      wallet=WALLET)
     elif in_row[9] in ("referral_bonus", "referral_card_cashback", "reimbursement",
-                       "gift_card_reward", "transfer_cashback", "admin_wallet_credited"):
+                       "gift_card_reward", "transfer_cashback", "admin_wallet_credited",
+                       "referral_gift"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_RECEIVED,
                                                  data_row.timestamp,
                                                  buy_quantity=in_row[3],


### PR DESCRIPTION
The date parser is a bit backwards. It returns broken results. For example, for an account opened in May 2020, it was reporting transactions for the 2019/2020 tax year because it swaps the month and day values. It also ignores the transactions for day 13+.

`referral_gift` is the transaction type when the signup bonus is unlocked after staking the required CRO. This is locked at signup, but visible for those who signed up via referral. Marked appropriately as Gift-Received.

This is an actual record which hits both issues:

```
2020-08-29 18:34:02,Sign-up Bonus Unlocked,CRO,248.82658889,,,USD,50.0,50.0,referral_gift
```

This is the date format exported by the Crypto.com app. It matches the format stored in the L column by `bittytax_conv` after applying this fix.