### PR TITLE
Add support for Nexo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - AttributeError: 'module' object has no attribute 'UTC'. ([#27](https://github.com/BittyTax/BittyTax/issues/27))
 ### Added
 - Conversion tool: added parser for CGTCalculator.
+- Conversion tool: added parser for Nexo.
 ### Changed
 - Hotbit parser: Negative fees are now set to zero.
 - Accounting tool: Drop buy/sell/fee transactions of zero quantity.

--- a/bittytax/conv/parsers/__init__.py
+++ b/bittytax/conv/parsers/__init__.py
@@ -25,6 +25,7 @@ from . import ii
 from . import kucoin
 from . import ledgerlive
 from . import liquid
+from . import nexo
 from . import okex
 from . import poloniex
 from . import qtwallet

--- a/bittytax/conv/parsers/nexo.py
+++ b/bittytax/conv/parsers/nexo.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# (c) Nano Nano Ltd 2020
+
+from decimal import Decimal
+
+from ..out_record import TransactionOutRecord
+from ..dataparser import DataParser
+from ..exceptions import UnexpectedTypeError
+
+WALLET = "Nexo"
+
+def parse_nexo(data_row, parser, _filename):
+    in_row = data_row.in_row
+    data_row.timestamp = DataParser.parse_timestamp(in_row[6])
+
+    if in_row[1] == "Deposit":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_DEPOSIT,
+                                                 data_row.timestamp,
+                                                 buy_quantity=Decimal(in_row[3]),
+                                                 buy_asset=in_row[2],
+                                                 wallet=WALLET)
+    elif in_row[1] == "Interest":
+        asset = in_row[2]
+        # Workaround: this looks like a bug in the exporter for Nexo interest payments
+        if asset == "NEXONEXO":
+            asset = "NEXO"
+
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_INTEREST,
+                                                 data_row.timestamp,
+                                                 buy_quantity=Decimal(in_row[3]),
+                                                 buy_asset=asset,
+                                                 wallet=WALLET)
+    elif in_row[1] == "Withdrawal":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_WITHDRAWAL,
+                                                 data_row.timestamp,
+                                                 sell_quantity=abs(Decimal(in_row[3])),
+                                                 sell_asset=in_row[2],
+                                                 wallet=WALLET)
+    else:
+        raise UnexpectedTypeError(1, parser.in_header[1], in_row[1])
+
+DataParser(DataParser.TYPE_WALLET,
+           "Nexo",
+           ['Transaction', 'Type', 'Currency', 'Amount', 'Details',
+           'Outstanding Loan', 'Date / Time'],
+           worksheet_name="Nexo",
+           row_handler=parse_nexo)


### PR DESCRIPTION
This adds support for https://nexo.io/. It supports just the earn product (deposit, interest, withdraw types) as I never used it to borrow, so I don't know how the transaction format looks like.

There's also a workaround for interests paid in NEXO as the CSV exporter lists the asset as NEXONEXO which can't be matched to an actual known token.

It is marked as `TYPE_WALLET` since Nexo doesn't really support converting crypto from one type to another, so it acts like a custodial wallet rather than exchange.

Example transactions:

```
Transaction,Type,Currency,Amount,Details,Outstanding Loan,Date / Time
XXX,Interest,NEXONEXO,1.26090511,approved / 0.00380478 LTC,$0.00,2020-11-23 01:00:00
XXX,Withdrawal,XLM,-1051.4,approved / XLM withdrawal,$0.00,2020-09-05 04:30:00
XXX,Interest,DAI,0.00490601,approved / DAI Interest Earned,$0.00,2020-06-19 01:00:00
XXX,Deposit,XLM,1042.7,approved / XXX,$0.00,2020-06-18 05:00:00
```