### PR TITLE
Coinbase parser: Handle Coinbase Earn entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Etherscan parser: added internal transactions export.
 - Binance parser: added cash deposit and withdrawal exports.
 - Binance parser: added statements export.
+- Coinbase parser: handle Coinbase Earn income.
 ### Changed
 - Conversion tool: UnknownAddressError exception changed to generic DataFilenameError.
 - Binance parser: use filename to determine if deposits or withdrawals.

--- a/bittytax/conv/parsers/coinbase.py
+++ b/bittytax/conv/parsers/coinbase.py
@@ -27,6 +27,12 @@ def parse_coinbase(data_row, parser, _filename):
                                                  buy_quantity=in_row[3],
                                                  buy_asset=in_row[2],
                                                  wallet=WALLET)
+    elif in_row[1] == "Coinbase Earn":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_INCOME,
+                                            data_row.timestamp,
+                                            buy_quantity=in_row[3],
+                                            buy_asset=in_row[2],
+                                            wallet=WALLET)
     elif in_row[1] == "Send":
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_WITHDRAWAL,
                                                  data_row.timestamp,


### PR DESCRIPTION
Hi @nanonano, I'm a massive fan of this project! You've just saved me a ton of time trying to calculate everything myself.

I've just checked today, and it seems like Coinbase's transaction history report now outputs Coinbase Earn transactions as well.

These transactions are earned from learning about crypto, e.g. by watching videos and answering quiz questions.

They seem to be considered income and not a gift in the US at least (see https://cryptotrader.tax/blog/coinbase-taxes), and the way I understand HMRC guidelines on airdrops, I believe they're technically income, so that's what I've put it under.

### Examples

An example line from the Coinbase exported `.csv` file:

```csv
Timestamp,Transaction Type,Asset,Quantity Transacted,GBP Spot Price at Transaction,GBP Subtotal,GBP Total (inclusive of fees),GBP Fees,Notes
2020-07-28T19:45:11Z,Coinbase Earn,EOS,0.6625,2.32,1.54,1.54,0.00,Received 0.6625 EOS from Coinbase Earn
```

And the resulting previous error before this pull request:

```console
ERROR Unrecognised Transaction Type: 'Coinbase Earn'
row[31] ['2020-07-28T19:45:11Z', 'Coinbase Earn', 'EOS', '0.6625', '2.32', '1.54', '1.54', '0.00', 'Received 0.6625 EOS from Coinbase Earn']
```

Thanks again for making this project open-source, and all the best wishes to you in 2021.