### PR TITLE
Fixed unrecognised transaction for rewards income - coinbase

### DIFF
--- a/bittytax/conv/parsers/coinbase.py
+++ b/bittytax/conv/parsers/coinbase.py
@@ -33,6 +33,12 @@ def parse_coinbase(data_row, parser, _filename):
                                             buy_quantity=in_row[3],
                                             buy_asset=in_row[2],
                                             wallet=WALLET)
+    elif in_row[1] == "Rewards Income":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_INCOME,
+                                            data_row.timestamp,
+                                            buy_quantity=in_row[3],
+                                            buy_asset=in_row[2],
+                                            wallet=WALLET)
     elif in_row[1] == "Send":
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_WITHDRAWAL,
                                                  data_row.timestamp,


### PR DESCRIPTION
'Rewards Income' type in coinbase transactions will be considered as income during conversion to bittytax records.
This change closes #43 