### PR TITLE
coinbase: fix the missing fiat currency deposits in transactions

### DIFF
--- a/bittytax/audit_fix/asset.py
+++ b/bittytax/audit_fix/asset.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# (c) Nano Nano Ltd 2020
+
+from . import coinbase
+
+class Asset(object):
+    ''' Search for missing asset '''
+    COINBASE_WALLET = 'Coinbase'
+
+    @staticmethod
+    def find_missing_asset(transaction):
+        if transaction.wallet == Asset.COINBASE_WALLET:
+            return coinbase.find_missing_asset(transaction.raw_row)
+       
+        return False, None, None

--- a/bittytax/audit_fix/coinbase.py
+++ b/bittytax/audit_fix/coinbase.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# (c) Nano Nano Ltd 2020
+
+from decimal import Decimal
+
+def find_missing_asset(raw_row):
+    ''' parse the notes in the transaction extracting the fiat currency amount used to buy asset.
+    For example: "Bought 0.01327044 BTC for £40.00 GBP" is deducted as 40 GBP missing asset
+    '''
+    asset = None
+    quantity = None
+    found = False
+    if len(raw_row) == 21:
+        notes = raw_row[20]
+        if notes.startswith('Bought') and 'for' in notes:
+            asset = notes.split()[-1]
+            quantity = Decimal(''.join([x for x in notes.split()[-2] if x.isdigit() or x == '.']))
+            found = True
+    
+    return found, asset, quantity

--- a/bittytax/import_records.py
+++ b/bittytax/import_records.py
@@ -43,7 +43,7 @@ class ImportRecords(object):
                 row = [self.convert_cell(worksheet.cell(row_num, cell_num), workbook)
                        for cell_num in range(0, worksheet.ncols)]
 
-                t_row = TransactionRow(row[:len(TransactionRow.HEADER)], row_num+1, worksheet.name)
+                t_row = TransactionRow(row[:len(TransactionRow.HEADER)], row_num+1, row, worksheet.name)
                 try:
                     t_row.parse()
                 except TransactionParserError as e:
@@ -162,8 +162,9 @@ class TransactionRow(object):
 
     cnt = 0
 
-    def __init__(self, row, row_num, worksheet_name=None):
+    def __init__(self, row, row_num, raw_row, worksheet_name=None):
         self.row = row
+        self.raw_row = raw_row
         self.row_num = row_num
         self.worksheet_name = worksheet_name
         self.t_record = None
@@ -205,7 +206,7 @@ class TransactionRow(object):
                 fee.disposal = False
 
         self.t_record = TransactionRecord(t_type, buy, sell, fee, self.row[10],
-                                          self.parse_timestamp(self.row[11]))
+                                          self.parse_timestamp(self.row[11]), self.raw_row)
 
     @staticmethod
     def parse_timestamp(timestamp_str):

--- a/bittytax/record.py
+++ b/bittytax/record.py
@@ -34,7 +34,7 @@ class TransactionRecord(object):
 
     cnt = 0
 
-    def __init__(self, t_type, buy, sell, fee, wallet, timestamp):
+    def __init__(self, t_type, buy, sell, fee, wallet, timestamp, raw_row):
         self.tid = None
         self.t_type = t_type
         self.buy = buy
@@ -42,6 +42,7 @@ class TransactionRecord(object):
         self.fee = fee
         self.wallet = wallet
         self.timestamp = timestamp
+        self.raw_row = raw_row
 
         if self.buy:
             self.buy.t_record = self

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'Programming Language :: Python :: 3.9',
     ],
     keywords='bittytax cryptoasset cryptocurrency crypto tax',
-    packages=['bittytax', 'bittytax.conv', 'bittytax.conv.parsers', 'bittytax.price'],
+    packages=['bittytax', 'bittytax.audit_fix', 'bittytax.conv', 'bittytax.conv.parsers', 'bittytax.price'],
     package_data={'bittytax': ['templates/*.html']},
     install_requires=[
         'python-dateutil>=2.7.0',


### PR DESCRIPTION
Coinbase doesn't show the fiat currency deposits in transactions when crypto is bought using debit or credit card. (Coinbase pro seems to be showing this well)

However, the notes column in the transaction shows the amount used to buy the crypto and this can be used to make the assumption that the deposit has taken place.

Transaction example (Coinbase):
Trade | 0.01327044 | BTC |   | 38.01 | GBP |   | 1.99 | GBP |   | Coinbase | 2019-01-15 20:14:09 | 2019-01-15T20:14:09Z | Buy | BTC | 0.01327044 | 2864.26 | 38.01 | 40.00 | 1.99 | Bought 0.01327044 BTC for £40.00 GBP
