### PR TITLE
fix(conv): add crypto_to_van_sell_order kind to cryptocom

### DIFF
--- a/bittytax/conv/parsers/cryptocom.py
+++ b/bittytax/conv/parsers/cryptocom.py
@@ -37,7 +37,7 @@ def parse_crypto_com(data_row, parser, _filename):
                                                  buy_asset=in_row[2],
                                                  buy_value=get_value(in_row),
                                                  wallet=WALLET)
-    elif in_row[9] in ("viban_purchase", "van_purchase",
+    elif in_row[9] in ("viban_purchase", "van_purchase", "crypto_to_van_sell_order",
                        "crypto_viban_exchange", "crypto_exchange"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
                                                  data_row.timestamp,


### PR DESCRIPTION
## Problem

Crypto.com transaction history CSVs now include a `crypto_to_van_sell_order` transaction kind for crypto to fiat transactions.

### Sample CSV Entry

Timestamp (UTC)|Transaction Description|Currency|Amount|To Currency|To Amount|Native Currency|Native Amount|Native Amount (in USD)|Transaction Kind
-|-|-|-|-|-|-|-|-|-
10/26/20 6:20 | CRO -> USD | CRO | -176.68 | USD | 17.13 | USD | -17.13 | -17.13 | crypto_to_van_sell_order

## Solution

Add `crypto_to_van_sell_order` to the list of transaction kinds that generate a `TYPE_TRADE` transaction record.