### PR TITLE
feat(conv): celsius parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Important:- A new Note field has been added to the end of the transaction record
 - Accounting tool: note field added to income report.
 - Conversion tool: note field added to the Excel and CSV output.
 - Accounting tool: new config "transfer_fee_disposal" added (transfers_include=False) ([#56](https://github.com/BittyTax/BittyTax/issues/56)).
+- Conversion tool: added parser for Celsius.
 ### Changed
 - Conversion tool: UnknownAddressError exception changed to generic DataFilenameError.
 - Binance parser: use filename to determine if deposits or withdrawals.

--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ For most wallet files, transactions can only be categorised as deposits or withd
 - Nexo
 - Qt Wallet (i.e. Bitcoin Core)
 - Trezor
+- Celsius
 
 **Exchanges:**
 - Binance

--- a/bittytax/conv/parsers/__init__.py
+++ b/bittytax/conv/parsers/__init__.py
@@ -3,6 +3,7 @@ from . import barclays
 from . import bitfinex
 from . import bitstamp
 from . import bittrex
+from . import celsius
 from . import cgtcalculator
 from . import changetip
 from . import circle

--- a/bittytax/conv/parsers/celsius.py
+++ b/bittytax/conv/parsers/celsius.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# (c) Nano Nano Ltd 2020
+
+import sys
+from decimal import Decimal
+
+from colorama import Fore, Back
+
+from ...config import config
+from ..out_record import TransactionOutRecord
+from ..dataparser import DataParser
+from ..exceptions import UnexpectedTypeError
+
+WALLET = "Celsius"
+
+
+def parse_celsius(data_row, parser, _filename):
+    in_row = data_row.in_row
+    data_row.timestamp = DataParser.parse_timestamp(in_row[1])
+
+    if in_row[8] != "Yes" and not config.args.unconfirmed:
+        sys.stderr.write("%srow[%s] %s\n" % (
+            Fore.YELLOW, parser.in_header_row_num + data_row.line_num, data_row))
+        sys.stderr.write("%sWARNING%s Skipping unconfirmed transaction, "
+                         "use the [-uc] option to include it\n" % (
+                             Back.YELLOW+Fore.BLACK, Back.RESET+Fore.YELLOW))
+        return
+
+    transaction_type = in_row[2]
+    symbol = in_row[3]
+    quantity = Decimal(in_row[4])
+    value = abs(Decimal(in_row[5])) if config.CCY == "USD" else None
+
+    if transaction_type == "deposit":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_DEPOSIT,
+                                                 data_row.timestamp,
+                                                 buy_quantity=quantity,
+                                                 buy_asset=symbol,
+                                                 wallet=WALLET)
+
+    elif transaction_type == "interest":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_INTEREST,
+                                                 data_row.timestamp,
+                                                 buy_quantity=quantity,
+                                                 buy_asset=symbol,
+                                                 buy_value=value,
+                                                 wallet=WALLET)
+
+    elif transaction_type in ("referred_award", "referrer_award", "promo_code_reward"):
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_RECEIVED,
+                                                 data_row.timestamp,
+                                                 buy_quantity=quantity,
+                                                 buy_asset=symbol,
+                                                 buy_value=value,
+                                                 wallet=WALLET)
+
+    elif transaction_type == "withdrawal":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_WITHDRAWAL,
+                                                 data_row.timestamp,
+                                                 sell_quantity=abs(quantity),
+                                                 sell_asset=symbol,
+                                                 wallet=WALLET)
+
+    else:
+        raise UnexpectedTypeError(2, parser.in_header[2], transaction_type)
+
+
+DataParser(DataParser.TYPE_WALLET,
+           "Celsius",
+           ['Internal id', ' Date and time', ' Transaction type', ' Coin type', ' Coin amount',
+            ' USD Value', ' Original Interest Coin', ' Interest Amount In Original Coin', ' Confirmed'],
+           worksheet_name="Celsius",
+           row_handler=parse_celsius)


### PR DESCRIPTION
Implements a conversion tool parser for [Celsius](https://celsius.network).

Same caveats as #31 apply - I've only used Celsius for their earn product and not for lending, so this may not cover all transaction types. In addition, much like Nexo, Celsius acts as a custodial wallet and does not have exchange functionality, so I've implemented it as `TYPE_WALLET`.

Sample input CSV:

```
Internal id, Date and time, Transaction type, Coin type, Coin amount, USD Value, Original Interest Coin, Interest Amount In Original Coin, Confirmed
1a91faeb-6446-47b3-8e66-d20fd5a96543,1/16/21 9:20,withdrawal,USDC,-500.000000,-500.000000,,,Yes
c9f7a1b7-09a3-4bcc-a9a8-16e512eea0c4,1/15/21 5:00,promo_code_reward,BTC,0.000764662,30.000000,,,No
43842923-8262-4c51-846c-c5b6fa481743,1/14/21 5:00,promo_code_reward,BTC,0.000533959,20.000000,,,Yes
7e7c0dcc-ac6b-4542-add6-295104c5b7b1,1/13/21 5:00,referrer_award,BTC,0.000736637,25.000000,,,Yes
96268a4c-bbbe-4d22-802b-0061f955bb36,1/11/21 5:00,referred_award,BTC,0.000651075,25.000000,,,Yes
04c56a40-90b2-472e-a5ff-cbafe2877bc0,1/11/21 5:00,interest,USDC,1.201923,1.200000,USDC,,Yes
3a285dd9-14df-428f-8e40-7d916fcf8c9c,1/5/21 13:46,deposit,USDC,500.000000,500.000000,,,Yes
```

Expected output:
```
$ bittytax_conv -s celsius_test.csv -o celsius_out.xlsx
file: celsius_test.csv matched as "Celsius"
row[3] ['c9f7a1b7-09a3-4bcc-a9a8-16e512eea0c4', '1/15/21 5:00', 'promo_code_reward', 'BTC', '0.000764662', '30.000000', '', '', 'No']
WARNING Skipping unconfirmed transaction, use the [-uc] option to include it
output EXCEL file created: celsius_out.xlsx
```

<img width="1040" alt="Screen Shot 2021-02-20 at 9 10 48 PM" src="https://user-images.githubusercontent.com/704880/108616199-22d17700-73c0-11eb-9964-7ca5a79d5aef.png">
