### PR TITLE
feat(conv): blockfi parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Important:- A new Note field has been added to the end of the transaction record
 - Accounting tool: note field added to income report.
 - Conversion tool: note field added to the Excel and CSV output.
 - Accounting tool: new config "transfer_fee_disposal" added (transfers_include=False) ([#56](https://github.com/BittyTax/BittyTax/issues/56)).
+- Conversion tool: added parser for BlockFi.
 ### Changed
 - Conversion tool: UnknownAddressError exception changed to generic DataFilenameError.
 - Binance parser: use filename to determine if deposits or withdrawals.

--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ For most wallet files, transactions can only be categorised as deposits or withd
 - Nexo
 - Qt Wallet (i.e. Bitcoin Core)
 - Trezor
+- BlockFi
 
 **Exchanges:**
 - Binance

--- a/bittytax/conv/parsers/__init__.py
+++ b/bittytax/conv/parsers/__init__.py
@@ -3,6 +3,7 @@ from . import barclays
 from . import bitfinex
 from . import bitstamp
 from . import bittrex
+from . import blockfi
 from . import cgtcalculator
 from . import changetip
 from . import circle

--- a/bittytax/conv/parsers/blockfi.py
+++ b/bittytax/conv/parsers/blockfi.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+# (c) Nano Nano Ltd 2021
+
+import sys
+from decimal import Decimal
+
+from colorama import Fore, Back
+
+from ...config import config
+from ..out_record import TransactionOutRecord
+from ..dataparser import DataParser
+from ..exceptions import UnexpectedTypeError
+
+WALLET = "BlockFi"
+
+
+def parse_blockfi_wallet(data_row, parser, _filename):
+    in_row = data_row.in_row
+
+    if in_row[3] == "" and not config.args.unconfirmed:
+        sys.stderr.write("%srow[%s] %s\n" % (
+            Fore.YELLOW, parser.in_header_row_num + data_row.line_num, data_row))
+        sys.stderr.write("%sWARNING%s Skipping unconfirmed transaction, "
+                         "use the [-uc] option to include it\n" % (
+                             Back.YELLOW+Fore.BLACK, Back.RESET+Fore.YELLOW))
+        return
+
+    data_row.timestamp = DataParser.parse_timestamp(in_row[3])
+
+    symbol = in_row[0]
+    quantity = Decimal(in_row[1])
+    transaction_type = in_row[2]
+
+    if "Deposit" in transaction_type:
+        # "Deposit" for crypto deposits
+        # "Wire Deposit" for wire transfers
+        # "ACH Deposit" for ACH transfers
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_DEPOSIT,
+                                                 data_row.timestamp,
+                                                 buy_quantity=quantity,
+                                                 buy_asset=symbol,
+                                                 wallet=WALLET)
+
+    elif transaction_type == "Interest Payment":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_INTEREST,
+                                                 data_row.timestamp,
+                                                 buy_quantity=quantity,
+                                                 buy_asset=symbol,
+                                                 wallet=WALLET)
+
+    elif transaction_type == "Bonus Payment":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_RECEIVED,
+                                                 data_row.timestamp,
+                                                 buy_quantity=quantity,
+                                                 buy_asset=symbol,
+                                                 wallet=WALLET)
+
+    elif transaction_type == "Withdrawal Fee":
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_SPEND,
+                                                 data_row.timestamp,
+                                                 sell_quantity=abs(quantity),
+                                                 sell_asset=symbol,
+                                                 wallet=WALLET)
+
+    elif "Withdrawal" in transaction_type:
+        # "Withdrawal" for crypto withdrawals
+        # "Wire Withdrawal" for wire transfers
+        # "ACH Withdrawal" for ACH transfers
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_WITHDRAWAL,
+                                                 data_row.timestamp,
+                                                 sell_quantity=abs(quantity),
+                                                 sell_asset=symbol,
+                                                 wallet=WALLET)
+
+    elif transaction_type == "Trade":
+        # BlockFi reports trades with more detail in a separate export
+        sys.stderr.write("%srow[%s] %s\n" % (
+            Fore.YELLOW, parser.in_header_row_num + data_row.line_num, data_row))
+        sys.stderr.write("%sWARNING%s Skipping trade transaction, "
+                         "make sure you also import your BlockFi trading report\n" % (
+                             Back.YELLOW+Fore.BLACK, Back.RESET+Fore.YELLOW))
+
+    else:
+        raise UnexpectedTypeError(2, parser.in_header[2], transaction_type)
+
+
+def parse_blockfi_trades(data_row, parser, _filename):
+    in_row = data_row.in_row
+    data_row.timestamp = DataParser.parse_timestamp(in_row[1])
+
+    data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
+                                             data_row.timestamp,
+                                             buy_quantity=Decimal(in_row[2]),
+                                             buy_asset=in_row[3],
+                                             sell_quantity=abs(
+                                                 Decimal(in_row[4])),
+                                             sell_asset=in_row[5],
+                                             wallet=WALLET)
+
+
+DataParser(DataParser.TYPE_WALLET,
+           "BlockFi",
+           ['Cryptocurrency', 'Amount', 'Transaction Type', 'Confirmed At'],
+           worksheet_name="BlockFi",
+           row_handler=parse_blockfi_wallet)
+
+DataParser(DataParser.TYPE_EXCHANGE,
+           "BlockFi Trades",
+           ['Trade ID', 'Date', 'Buy Quantity', 'Buy Currency', 'Sold Quantity',
+            'Sold Currency', 'Rate Amount', 'Rate Currency', 'Type'],
+           worksheet_name="BlockFi T",
+           row_handler=parse_blockfi_trades)


### PR DESCRIPTION
Implements a conversion tool parser for [BlockFi](https://blockfi.com).

Same caveats as #31 and #69 apply - I've only used BlockFi for their earn product and not for lending, so this may not cover all transaction types. Unlike Nexo and Celsius, however, BlockFi does support buying/selling their supported symbols, and they provide a separate export for trade transactions. ~Unfortunately, I do not have an example export CSV to reference to implement a parser; when one becomes available, I think it would make sense to implement this like Binance and have a separate `TYPE_EXCHANGE` parser in addition to the `TYPE_WALLET` parser implemented in this PR.~

Sample input CSVs:

###### blockfi_wallet_sample.csv
```
Cryptocurrency,Amount,Transaction Type,Confirmed At
USDC,-1000,Withdrawal,1/16/21 9:48
BTC,0.00737669,Bonus Payment,1/15/21 23:59
USDC,7.025507246,Interest Payment,12/31/20 23:59
USDC,5.409836064,Interest Payment,12/1/20 4:59
USDC,10,Deposit,
BTC,0.0625,Trade,11/15/20 13:34
GUSD,-1000,Trade,11/15/20 13:34
USDC,1000,Deposit,11/6/20 16:21
GUSD,1000,Wire Deposit,11/1/20 9:30
```

###### blockfi_trades_sample.csv
```
Trade ID,Date,Buy Quantity,Buy Currency,Sold Quantity,Sold Currency,Rate Amount,Rate Currency,Type
63ff4494-135e-4f92-b8ec-6694c037ebf7,1/15/20 13:34,0.0625,btc,1000,gusd,16000,gusd,One Time
```

Expected output:
```
$ bittytax_conv -s blockfi_wallet_sample.csv blockfi_trades_sample.csv -o blockfi_out.xlsx
file: blockfi_wallet_sample.csv matched as "BlockFi"
row[6] ['USDC', '10', 'Deposit', '']
WARNING Skipping unconfirmed transaction, use the [-uc] option to include it
row[7] ['BTC', '0.0625', 'Trade', '11/15/20 13:34']
WARNING Skipping trade transaction, make sure you also import your BlockFi trading report
row[8] ['GUSD', '-1000', 'Trade', '11/15/20 13:34']
WARNING Skipping trade transaction, make sure you also import your BlockFi trading report
file: blockfi_trades_sample.csv matched as "BlockFi T"
gusd
output EXCEL file created: blockfi_out.xlsx
```

<img width="1025" alt="Screen Shot 2021-02-21 at 6 38 10 PM" src="https://user-images.githubusercontent.com/704880/108650473-80bf9680-7474-11eb-99d7-d9afc30d2eac.png">
<img width="977" alt="Screen Shot 2021-02-21 at 6 38 27 PM" src="https://user-images.githubusercontent.com/704880/108650477-81f0c380-7474-11eb-9e6f-a3790e3b5f88.png">

