### PR TITLE
fix Crypto.com App many fixes

### DIFF
--- a/bittytax/conv/parsers/cryptocom.py
+++ b/bittytax/conv/parsers/cryptocom.py
@@ -10,25 +10,42 @@ from ..exceptions import UnexpectedTypeError
 
 WALLET = "Crypto.com"
 
-def parse_crypto_com(data_row, parser, _filename):
+def parse_crypto_com(data_row, parser, filename):
     in_row = data_row.in_row
     data_row.timestamp = DataParser.parse_timestamp(in_row[0])
+    comment = in_row[1]
 
-    if in_row[9] == "crypto_transfer":
+    if "fiat" in filename.lower():
+        # FIAT wallet export is required for proper FIAT audit.
+        if in_row[9] not in ("viban_card_top_up", "viban_withdrawal", "viban_deposit"):
+            # We need to ignore the duplicates already found in the "transactions" file.
+            return
+        if in_row[9] == "viban_card_top_up":
+            # Moving from fiat wallet to card wallet requires parsing the "card" csv file. Until someone volunteers to
+            # do that accurately, we'll just spend the money on the card.
+            data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_SPEND,
+                                                     data_row.timestamp,
+                                                     sell_quantity=abs(Decimal(in_row[3])),
+                                                     sell_asset=in_row[2],
+                                                     sell_value=get_value(in_row),
+                                                     wallet=WALLET, note=comment)
+            return
+
+    if in_row[9] in ("crypto_transfer", "airdrop_locked"):
         if Decimal(in_row[3]) > 0:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_RECEIVED,
                                                      data_row.timestamp,
                                                      buy_quantity=in_row[3],
                                                      buy_asset=in_row[2],
                                                      buy_value=get_value(in_row),
-                                                     wallet=WALLET)
+                                                     wallet=WALLET, note=comment)
         else:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_SENT,
                                                      data_row.timestamp,
                                                      sell_quantity=abs(Decimal(in_row[3])),
                                                      sell_asset=in_row[2],
                                                      sell_value=get_value(in_row),
-                                                     wallet=WALLET)
+                                                     wallet=WALLET, note=comment)
     elif in_row[9] in ("crypto_earn_interest_paid", "mco_stake_reward",
                        "crypto_earn_extra_interest_paid"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_INTEREST,
@@ -36,7 +53,7 @@ def parse_crypto_com(data_row, parser, _filename):
                                                  buy_quantity=in_row[3],
                                                  buy_asset=in_row[2],
                                                  buy_value=get_value(in_row),
-                                                 wallet=WALLET)
+                                                 wallet=WALLET, note=comment)
     elif in_row[9] in ("viban_purchase", "van_purchase",
                        "crypto_viban_exchange", "crypto_exchange"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
@@ -46,25 +63,39 @@ def parse_crypto_com(data_row, parser, _filename):
                                                  sell_quantity=abs(Decimal(in_row[3])),
                                                  sell_asset=in_row[2],
                                                  sell_value=get_value(in_row),
-                                                 wallet=WALLET)
-    elif in_row[9] in ("crypto_purchase", "dust_conversion_debited", "dust_conversion_credited"):
+                                                 wallet=WALLET, note=comment)
+    elif in_row[9] in ("crypto_wallet_swap_credited", "crypto_wallet_swap_debited",
+                       "interest_swap_credited", "interest_swap_debited",
+                       "lockup_swap_credited", "lockup_swap_debited",
+                       "dust_conversion_debited",
+                       "dust_conversion_credited"):
         if Decimal(in_row[3]) > 0:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
                                                      data_row.timestamp,
                                                      buy_quantity=in_row[3],
                                                      buy_asset=in_row[2],
-                                                     sell_quantity=in_row[7],
+                                                     sell_quantity=0,
                                                      sell_asset=in_row[6],
-                                                     wallet=WALLET)
+                                                     wallet=WALLET, note=comment)
         else:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
                                                      data_row.timestamp,
-                                                     buy_quantity=abs(Decimal(in_row[7])),
+                                                     buy_quantity=0,
                                                      buy_asset=in_row[6],
                                                      sell_quantity=abs(Decimal(in_row[3])),
                                                      sell_asset=in_row[2],
-                                                     wallet=WALLET)
-    elif in_row[9] in ("referral_bonus", "referral_card_cashback", "reimbursement",
+                                                     wallet=WALLET, note=comment)
+    elif in_row[9] == "crypto_purchase":
+        # This is a purchase of crypto with a credit card. Do NOT subtract from fiat.
+        # For tax purposes, this needs to be a deposit, not a trade with a price of zero.
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_DEPOSIT,
+                                                 data_row.timestamp,
+                                                 buy_quantity=in_row[3],
+                                                 buy_asset=in_row[2],
+                                                 sell_quantity=None,
+                                                 sell_asset='',
+                                                 wallet=WALLET, note=comment)
+    elif in_row[9] in ("referral_bonus", "referral_card_cashback", "referral_commission", "reimbursement",
                        "gift_card_reward", "transfer_cashback", "admin_wallet_credited",
                        "referral_gift", "campaign_reward"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_RECEIVED,
@@ -72,7 +103,7 @@ def parse_crypto_com(data_row, parser, _filename):
                                                  buy_quantity=in_row[3],
                                                  buy_asset=in_row[2],
                                                  buy_value=get_value(in_row),
-                                                 wallet=WALLET)
+                                                 wallet=WALLET, note=comment)
 
     elif in_row[9] in ("card_cashback_reverted", "reimbursement_reverted"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_SENT,
@@ -80,58 +111,67 @@ def parse_crypto_com(data_row, parser, _filename):
                                                  sell_quantity=abs(Decimal(in_row[3])),
                                                  sell_asset=in_row[2],
                                                  sell_value=get_value(in_row),
-                                                 wallet=WALLET)
+                                                 wallet=WALLET, note=comment)
     elif in_row[9] in ("crypto_payment", "card_top_up"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_SPEND,
                                                  data_row.timestamp,
                                                  sell_quantity=abs(Decimal(in_row[3])),
                                                  sell_asset=in_row[2],
                                                  sell_value=get_value(in_row),
-                                                 wallet=WALLET)
-    elif in_row[9] in ("crypto_withdrawal", "crypto_to_exchange_transfer"):
+                                                 wallet=WALLET, note=comment)
+    elif in_row[9] in ("crypto_withdrawal", "crypto_to_exchange_transfer", "airdrop_to_exchange_transfer",
+                       "invest_deposit", "viban_withdrawal"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_WITHDRAWAL,
                                                  data_row.timestamp,
                                                  sell_quantity=abs(Decimal(in_row[3])),
                                                  sell_asset=in_row[2],
                                                  sell_value=get_value(in_row),
-                                                 wallet=WALLET)
-    elif in_row[9] in ("crypto_deposit", "exchange_to_crypto_transfer"):
+                                                 wallet=WALLET, note=comment)
+    elif in_row[9] in ("crypto_deposit", "exchange_to_crypto_transfer", "invest_withdrawal", "viban_deposit"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_DEPOSIT,
                                                  data_row.timestamp,
                                                  buy_quantity=in_row[3],
                                                  buy_asset=in_row[2],
                                                  buy_value=get_value(in_row),
-                                                 wallet=WALLET)
+                                                 wallet=WALLET, note=comment)
     elif in_row[9] in ("crypto_earn_program_created", "crypto_earn_program_withdrawn",
-                       "lockup_lock", "lockup_upgrade",
-                       "lockup_swap_credited", "lockup_swap_debited",
-                       "dynamic_coin_swap_credited", "dynamic_coin_swap_debited",
-                       "dynamic_coin_swap_bonus_exchange_deposit",
-                       "interest_swap_credited", "interest_swap_debited",
-                       "crypto_wallet_swap_credited", "crypto_wallet_swap_debited",
-                       "supercharger_deposit", "supercharger_withdrawal"):
+                     "lockup_lock", "lockup_upgrade", "lockup_unlock",
+                     "supercharger_deposit", "supercharger_withdrawal"):
+        # These are CDC app specific functions, but the balance remains the same.
+        # Only skip app/functionality rows that do not affect your total balance.
+        return
+    elif in_row[9] in ("dynamic_coin_swap_credited", "dynamic_coin_swap_debited"):
+        # This is just information but it doesn't actually change your balance.
+        return
+    elif in_row[9] == "dynamic_coin_swap_bonus_exchange_deposit":
+        # This is a gift created out of thin air and immediately transferred to the exchange.
+        # Therefore it's a gift followed by a withdrawal, which requires two records but we only have one.
+        # One solution is to ignore this, and leave it up to the exchange audit to mark the deposit as gift.
         return
     elif in_row[9] == "":
+        # This is not supposed to happen
         # Could be a fiat transaction
         if "Deposit" in in_row[1]:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_DEPOSIT,
                                                      data_row.timestamp,
                                                      buy_quantity=in_row[3],
                                                      buy_asset=in_row[2],
-                                                     wallet=WALLET)
+                                                     wallet=WALLET, note=comment)
         elif "Withdrawal" in in_row[1]:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_WITHDRAWAL,
                                                      data_row.timestamp,
                                                      sell_quantity=abs(Decimal(in_row[3])),
                                                      sell_asset=in_row[2],
-                                                     wallet=WALLET)
+                                                     wallet=WALLET, note=comment)
     else:
         raise UnexpectedTypeError(9, parser.in_header[9], in_row[9])
+
 
 def get_value(in_row):
     if in_row[6] == config.CCY:
         return abs(Decimal(in_row[7]))
     return None
+
 
 DataParser(DataParser.TYPE_EXCHANGE,
            "Crypto.com",

--- a/bittytax/conv/parsers/cryptocom.py
+++ b/bittytax/conv/parsers/cryptocom.py
@@ -10,167 +10,186 @@ from ..exceptions import UnexpectedTypeError
 
 WALLET = "Crypto.com"
 
+
 def parse_crypto_com(data_row, parser, filename):
+    """
+    Use crypto_transactions.svg. If you ever used your fiat wallet, also use crypto_fiat.svg or the audit will fail.
+    The headers are the same, so the fiat file will be detected from the name. Don't rename the file (or keep 'fiat').
+
+    IMPORTANT NOTE!
+
+    There is an error in the csv export where any MCO left in "Earn" during the CRO swap around August 2020 does
+    not have a corresponding record for the swap to CRO. The first CRO withdrawal from "Earn" after the swap
+    divided by the MCO-CRO rate at the time probably shows exactly how much you had in earn. You need to manually
+    add a transaction for this using mco_early_swap_value = 27.64389999999996. Only if you had MCO in earn.
+
+    E.g. if your transaction looks like this:
+        2020-10-01 01:30:32,Crypto Earn Withdrawal,CRO,8293.17,,,EUR,1080.39,1287.88,crypto_earn_program_withdrawn
+    Add the following conversion:
+        2020-10-01 01:30:31,MANUAL FIX SWAP STUCK MCO EARN,MCO,-300,CRO,8293.17,EUR,1080.39,1287.88,crypto_exchange
+    Or save it to a separate file called crypto_manual_fixes.cvs and load it into bittytax_conv together with the
+    transactions.csv and fiat.csv.
+    """
     in_row = data_row.in_row
-    data_row.timestamp = DataParser.parse_timestamp(in_row[0])
-    comment = in_row[1]
+    header = parser.header
+    data_row.timestamp = DataParser.parse_timestamp(in_row[header.index('Timestamp (UTC)')])
+    comment = in_row[header.index('Transaction Description')]
+    tx_type = in_row[header.index('Transaction Kind')]
+    asset = in_row[header.index('Currency')]
+    quantity = in_row[header.index('Amount')]
+    to_asset = in_row[header.index('To Currency')]
+    to_quantity = in_row[header.index('To Amount')]
+    fiat_asset = in_row[header.index('Native Currency')]
+    fiat_quantity = abs(Decimal(in_row[header.index('Native Amount')])) if fiat_asset == config.CCY else None
 
     if "fiat" in filename.lower():
         # FIAT wallet export is required for proper FIAT audit.
-        if in_row[9] not in ("viban_card_top_up", "viban_withdrawal", "viban_deposit"):
+        if tx_type not in ("viban_card_top_up", "viban_withdrawal", "viban_deposit"):
             # We need to ignore the duplicates already found in the "transactions" file.
             return
-        if in_row[9] == "viban_card_top_up":
+        if tx_type == "viban_card_top_up":
             # Moving from fiat wallet to card wallet requires parsing the "card" csv file. Until someone volunteers to
             # do that accurately, we'll just spend the money on the card.
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_SPEND,
                                                      data_row.timestamp,
-                                                     sell_quantity=abs(Decimal(in_row[3])),
-                                                     sell_asset=in_row[2],
-                                                     sell_value=get_value(in_row),
+                                                     sell_quantity=abs(Decimal(quantity)),
+                                                     sell_asset=asset,
+                                                     sell_value=fiat_quantity,
                                                      wallet=WALLET, note=comment)
             return
 
-    if in_row[9] in ("crypto_transfer", "airdrop_locked"):
-        if Decimal(in_row[3]) > 0:
+    if tx_type in ("crypto_transfer", "airdrop_locked"):
+        if Decimal(quantity) > 0:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_RECEIVED,
                                                      data_row.timestamp,
-                                                     buy_quantity=in_row[3],
-                                                     buy_asset=in_row[2],
-                                                     buy_value=get_value(in_row),
+                                                     buy_quantity=quantity,
+                                                     buy_asset=asset,
+                                                     buy_value=fiat_quantity,
                                                      wallet=WALLET, note=comment)
         else:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_SENT,
                                                      data_row.timestamp,
-                                                     sell_quantity=abs(Decimal(in_row[3])),
-                                                     sell_asset=in_row[2],
-                                                     sell_value=get_value(in_row),
+                                                     sell_quantity=abs(Decimal(quantity)),
+                                                     sell_asset=asset,
+                                                     sell_value=fiat_quantity,
                                                      wallet=WALLET, note=comment)
-    elif in_row[9] in ("crypto_earn_interest_paid", "mco_stake_reward",
-                       "crypto_earn_extra_interest_paid"):
+    elif tx_type in ("crypto_earn_interest_paid", "crypto_earn_extra_interest_paid", "mco_stake_reward"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_INTEREST,
                                                  data_row.timestamp,
-                                                 buy_quantity=in_row[3],
-                                                 buy_asset=in_row[2],
-                                                 buy_value=get_value(in_row),
+                                                 buy_quantity=quantity,
+                                                 buy_asset=asset,
+                                                 buy_value=fiat_quantity,
                                                  wallet=WALLET, note=comment)
-    elif in_row[9] in ("viban_purchase", "van_purchase",
-                       "crypto_viban_exchange", "crypto_exchange"):
+    elif tx_type in ("viban_purchase", "van_purchase",
+                     "crypto_viban_exchange", "crypto_exchange"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
                                                  data_row.timestamp,
-                                                 buy_quantity=in_row[5],
-                                                 buy_asset=in_row[4],
-                                                 sell_quantity=abs(Decimal(in_row[3])),
-                                                 sell_asset=in_row[2],
-                                                 sell_value=get_value(in_row),
+                                                 buy_quantity=to_quantity,
+                                                 buy_asset=to_asset,
+                                                 sell_quantity=abs(Decimal(quantity)),
+                                                 sell_asset=asset,
+                                                 sell_value=fiat_quantity,
                                                  wallet=WALLET, note=comment)
-    elif in_row[9] in ("crypto_wallet_swap_credited", "crypto_wallet_swap_debited",
-                       "interest_swap_credited", "interest_swap_debited",
-                       "lockup_swap_credited", "lockup_swap_debited",
-                       "dust_conversion_debited",
-                       "dust_conversion_credited"):
-        if Decimal(in_row[3]) > 0:
+    elif tx_type in ("crypto_wallet_swap_credited", "crypto_wallet_swap_debited",
+                     "interest_swap_credited", "interest_swap_debited",
+                     "lockup_swap_credited", "lockup_swap_debited",
+                     "dust_conversion_debited",
+                     "dust_conversion_credited"):
+        if Decimal(quantity) > 0:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
                                                      data_row.timestamp,
-                                                     buy_quantity=in_row[3],
-                                                     buy_asset=in_row[2],
+                                                     buy_quantity=quantity,
+                                                     buy_asset=asset,
                                                      sell_quantity=0,
-                                                     sell_asset=in_row[6],
+                                                     sell_asset=fiat_asset,
                                                      wallet=WALLET, note=comment)
         else:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
                                                      data_row.timestamp,
                                                      buy_quantity=0,
-                                                     buy_asset=in_row[6],
-                                                     sell_quantity=abs(Decimal(in_row[3])),
-                                                     sell_asset=in_row[2],
+                                                     buy_asset=fiat_asset,
+                                                     sell_quantity=abs(Decimal(quantity)),
+                                                     sell_asset=asset,
                                                      wallet=WALLET, note=comment)
-    elif in_row[9] == "crypto_purchase":
+    elif tx_type == "crypto_purchase":
         # This is a purchase of crypto with a credit card. Do NOT subtract from fiat.
         # For tax purposes, this needs to be a deposit, not a trade with a price of zero.
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_DEPOSIT,
                                                  data_row.timestamp,
-                                                 buy_quantity=in_row[3],
-                                                 buy_asset=in_row[2],
+                                                 buy_quantity=quantity,
+                                                 buy_asset=asset,
                                                  sell_quantity=None,
                                                  sell_asset='',
                                                  wallet=WALLET, note=comment)
-    elif in_row[9] in ("referral_bonus", "referral_card_cashback", "referral_commission", "reimbursement",
-                       "gift_card_reward", "transfer_cashback", "admin_wallet_credited",
-                       "referral_gift", "campaign_reward"):
+    elif tx_type in ("referral_bonus", "referral_card_cashback", "referral_commission", "reimbursement",
+                     "gift_card_reward", "transfer_cashback", "admin_wallet_credited",
+                     "referral_gift", "campaign_reward"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_RECEIVED,
                                                  data_row.timestamp,
-                                                 buy_quantity=in_row[3],
-                                                 buy_asset=in_row[2],
-                                                 buy_value=get_value(in_row),
+                                                 buy_quantity=quantity,
+                                                 buy_asset=asset,
+                                                 buy_value=fiat_quantity,
                                                  wallet=WALLET, note=comment)
-
-    elif in_row[9] in ("card_cashback_reverted", "reimbursement_reverted"):
+    elif tx_type in ("card_cashback_reverted", "reimbursement_reverted"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_GIFT_SENT,
                                                  data_row.timestamp,
-                                                 sell_quantity=abs(Decimal(in_row[3])),
-                                                 sell_asset=in_row[2],
-                                                 sell_value=get_value(in_row),
+                                                 sell_quantity=abs(Decimal(quantity)),
+                                                 sell_asset=asset,
+                                                 sell_value=fiat_quantity,
                                                  wallet=WALLET, note=comment)
-    elif in_row[9] in ("crypto_payment", "card_top_up"):
+    elif tx_type in ("crypto_payment", "card_top_up"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_SPEND,
                                                  data_row.timestamp,
-                                                 sell_quantity=abs(Decimal(in_row[3])),
-                                                 sell_asset=in_row[2],
-                                                 sell_value=get_value(in_row),
+                                                 sell_quantity=abs(Decimal(quantity)),
+                                                 sell_asset=asset,
+                                                 sell_value=fiat_quantity,
                                                  wallet=WALLET, note=comment)
-    elif in_row[9] in ("crypto_withdrawal", "crypto_to_exchange_transfer", "airdrop_to_exchange_transfer",
-                       "invest_deposit", "viban_withdrawal"):
+    elif tx_type in ("crypto_withdrawal", "crypto_to_exchange_transfer", "airdrop_to_exchange_transfer",
+                     "invest_deposit", "viban_withdrawal"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_WITHDRAWAL,
                                                  data_row.timestamp,
-                                                 sell_quantity=abs(Decimal(in_row[3])),
-                                                 sell_asset=in_row[2],
-                                                 sell_value=get_value(in_row),
+                                                 sell_quantity=abs(Decimal(quantity)),
+                                                 sell_asset=asset,
+                                                 sell_value=fiat_quantity,
                                                  wallet=WALLET, note=comment)
-    elif in_row[9] in ("crypto_deposit", "exchange_to_crypto_transfer", "invest_withdrawal", "viban_deposit"):
+    elif tx_type in ("crypto_deposit", "exchange_to_crypto_transfer", "invest_withdrawal", "viban_deposit"):
         data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_DEPOSIT,
                                                  data_row.timestamp,
-                                                 buy_quantity=in_row[3],
-                                                 buy_asset=in_row[2],
-                                                 buy_value=get_value(in_row),
+                                                 buy_quantity=quantity,
+                                                 buy_asset=asset,
+                                                 buy_value=fiat_quantity,
                                                  wallet=WALLET, note=comment)
-    elif in_row[9] in ("crypto_earn_program_created", "crypto_earn_program_withdrawn",
+    elif tx_type in ("crypto_earn_program_created", "crypto_earn_program_withdrawn",
                      "lockup_lock", "lockup_upgrade", "lockup_unlock",
                      "supercharger_deposit", "supercharger_withdrawal"):
         # These are CDC app specific functions, but the balance remains the same.
         # Only skip app/functionality rows that do not affect your total balance.
         return
-    elif in_row[9] in ("dynamic_coin_swap_credited", "dynamic_coin_swap_debited"):
+    elif tx_type in ("dynamic_coin_swap_credited", "dynamic_coin_swap_debited"):
         # This is just information but it doesn't actually change your balance.
         return
-    elif in_row[9] == "dynamic_coin_swap_bonus_exchange_deposit":
+    elif tx_type == "dynamic_coin_swap_bonus_exchange_deposit":
         # This is a gift created out of thin air and immediately transferred to the exchange.
         # Therefore it's a gift followed by a withdrawal, which requires two records but we only have one.
         # One solution is to ignore this, and leave it up to the exchange audit to mark the deposit as gift.
         return
-    elif in_row[9] == "":
+    elif tx_type == "":
         # This is not supposed to happen
         # Could be a fiat transaction
         if "Deposit" in in_row[1]:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_DEPOSIT,
                                                      data_row.timestamp,
-                                                     buy_quantity=in_row[3],
-                                                     buy_asset=in_row[2],
+                                                     buy_quantity=quantity,
+                                                     buy_asset=asset,
                                                      wallet=WALLET, note=comment)
         elif "Withdrawal" in in_row[1]:
             data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_WITHDRAWAL,
                                                      data_row.timestamp,
-                                                     sell_quantity=abs(Decimal(in_row[3])),
-                                                     sell_asset=in_row[2],
+                                                     sell_quantity=abs(Decimal(quantity)),
+                                                     sell_asset=asset,
                                                      wallet=WALLET, note=comment)
     else:
-        raise UnexpectedTypeError(9, parser.in_header[9], in_row[9])
-
-
-def get_value(in_row):
-    if in_row[6] == config.CCY:
-        return abs(Decimal(in_row[7]))
-    return None
+        raise UnexpectedTypeError(9, parser.in_header[9], tx_type)
 
 
 DataParser(DataParser.TYPE_EXCHANGE,


### PR DESCRIPTION
Current parser has many issues that become apparent with a more complex history file. This version makes sure all the record types balance properly.

This PR fixes #96

I split the PR into three commits so you can see the functional changes more clearly in the diffs. Especially the first commit.

1. First diff: bdc092f
2. Second diff: c5b8d96b
3. Third diff: e35e6a21

All versions are functionally identical. I preferred the last approach, as it is more easily maintainable the next time CDC adds new record types.