### PR TITLE
Etherscan added "Method" parameter

### DIFF
--- a/bittytax/conv/parsers/etherscan.py
+++ b/bittytax/conv/parsers/etherscan.py
@@ -98,7 +98,7 @@ DataParser(DataParser.TYPE_EXPLORER,
            "Etherscan (Ethereum Transactions)",
            ['Txhash', 'Blockno', 'UnixTimestamp', 'DateTime', 'From', 'To', 'ContractAddress',
             'Value_IN(ETH)', 'Value_OUT(ETH)', None, 'TxnFee(ETH)', 'TxnFee(USD)',
-            'Historical $Price/Eth', 'Status', 'ErrCode'],
+            'Historical $Price/Eth', 'Status', 'ErrCode', 'Method'],
            worksheet_name="Etherscan",
            row_handler=parse_etherscan)
 
@@ -106,7 +106,7 @@ DataParser(DataParser.TYPE_EXPLORER,
            "Etherscan (Ethereum Transactions)",
            ['Txhash', 'Blockno', 'UnixTimestamp', 'DateTime', 'From', 'To', 'ContractAddress',
             'Value_IN(ETH)', 'Value_OUT(ETH)', None, 'TxnFee(ETH)', 'TxnFee(USD)',
-            'Historical $Price/Eth', 'Status', 'ErrCode', 'PrivateNote'],
+            'Historical $Price/Eth', 'Status', 'ErrCode', 'Method', 'PrivateNote'],
            worksheet_name="Etherscan",
            row_handler=parse_etherscan)
 


### PR DESCRIPTION
Etherscan seems to have added an additional parameter called "Method" to their CSV exports.
I've added this parameter in the parser and that seems to be all that is necessary.