### PR TITLE
Add start of tax year day/month to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,6 +792,9 @@ If you need to change anything, the parameters are described below. The file is 
 | `data_source_fiat:` | `['ExchangeRatesAPI', 'RatesAPI']` | Default data source(s) to use for fiat prices |
 | `data_source_crypto:` | `['CryptoCompare', 'CoinGecko']` | Default data source(s) to use for cryptoasset prices |
 | `usernames:` | | List of usernames as used by ChangeTip |
+| `start_of_year_day:` | `6` | The tax year start day (the default day is April the 6th) |
+| `start_of_year_month:` | `4` | The tax year start month |
+
 
 ### fiat_list
 Used to differentiate between fiat and cryptoassets symbols. Make sure you configure all fiat currencies which appear within your transaction records here.

--- a/bittytax/config.py
+++ b/bittytax/config.py
@@ -60,12 +60,12 @@ class Config(object):
         'data_source_fiat': DATA_SOURCE_FIAT,
         'data_source_crypto': DATA_SOURCE_CRYPTO,
         'coinbase_zero_fees_are_gifts': False,
+        'start_of_year_day': 6,
++       'start_of_year_month': 4,
     }
 
     def __init__(self):
         self.debug = False
-        self.start_of_year_month = 4
-        self.start_of_year_day = 6
 
         if not os.path.exists(Config.BITTYTAX_PATH):
             os.mkdir(Config.BITTYTAX_PATH)


### PR DESCRIPTION
Add functionality to customise the start of the tax month/day (New Zealand's tax year starts from the 1st of April)