### PR TITLE
Conversion tool: add support for staking and fork to Koinly parser

### DIFF
--- a/bittytax/conv/parsers/koinly.py
+++ b/bittytax/conv/parsers/koinly.py
@@ -18,7 +18,9 @@ KOINLY_D_MAPPING = {'': TransactionOutRecord.TYPE_GIFT_RECEIVED,
                     'reward': TransactionOutRecord.TYPE_GIFT_RECEIVED,
                     'income': TransactionOutRecord.TYPE_INCOME,
                     'loan_interest': TransactionOutRecord.TYPE_INTEREST,
-                    'realized_gain': None}
+                    'realized_gain': None,
+                    'staking': TransactionOutRecord.TYPE_STAKING,
+                    'fork': TransactionOutRecord.TYPE_GIFT_RECEIVED}
 
 KOINLY_W_MAPPING = {'': TransactionOutRecord.TYPE_GIFT_SENT,
                     'gift': TransactionOutRecord.TYPE_GIFT_SENT,


### PR DESCRIPTION
Adds support for lines of the form:
```
['2019-06-01 03:30:46 UTC', 'crypto_deposit', 'fork', '', '', '', '', 'EXCH_A', '1.23456789, 'ETC', '', '', '', '', '0.0', '', '', '', '', '']
['2020-09-05 10:35:24 UTC', 'crypto_deposit', 'staking', '', '', '', '', 'EXCH_B', '1.23456789', 'XYZ', '3.45678901', '', '', '', '3.45678901', '', '', '', '', 'XYZ Stake Rewards']
```