### PR TITLE
Added 'Staking Rewards', and Assets Sent / Credited for Staking to the Bitstamp Parser.

### DIFF
--- a/bittytax/conv/parsers/bitstamp.py
+++ b/bittytax/conv/parsers/bitstamp.py
@@ -51,6 +51,28 @@ def parse_bitstamp(data_row, parser, **_kwargs):
                                                      fee_quantity=fee_quantity,
                                                      fee_asset=fee_asset,
                                                      wallet=WALLET)
+        elif row_dict['Type'] in ("Sent assets to staking", "Market"):
+            data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
+                                                     data_row.timestamp,
+                                                     sell_quantity=row_dict['Amount'].split(' ')[0],
+                                                     sell_asset=row_dict['Amount'].split(' ')[1],
+                                                     buy_quantity="0",
+                                                     buy_asset="GBP",
+                                                     wallet=WALLET)
+        elif row_dict['Type'] in ("Credited with staked assets", "Market"):
+            data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
+                                                     data_row.timestamp,
+                                                     buy_quantity=row_dict['Amount'].split(' ')[0],
+                                                     buy_asset=row_dict['Amount'].split(' ')[1],
+                                                     sell_quantity="0",
+                                                     sell_asset="GBP",
+                                                     wallet=WALLET)
+        elif row_dict['Type'] in ("Staking reward", "Market"):
+            data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_STAKING,
+                                                     data_row.timestamp,
+                                                     buy_quantity=row_dict['Amount'].split(' ')[0],
+                                                     buy_asset=row_dict['Amount'].split(' ')[1],
+                                                     wallet=WALLET)
         else:
             raise UnexpectedTypeError(parser.in_header.index('Sub Type'), 'Sub Type',
                                       row_dict['Sub Type'])

--- a/bittytax/conv/parsers/bitstamp.py
+++ b/bittytax/conv/parsers/bitstamp.py
@@ -23,34 +23,6 @@ def parse_bitstamp(data_row, parser, **_kwargs):
                                                  sell_quantity=row_dict['Amount'].split(' ')[0],
                                                  sell_asset=row_dict['Amount'].split(' ')[1],
                                                  wallet=WALLET)
-    elif row_dict['Type'] in ("Staking", "Staking"):
-        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_STAKING,
-                                                 data_row.timestamp,
-                                                 sell_quantity=row_dict['Amount'].split(' ')[0],
-                                                 sell_asset=row_dict['Amount'].split(' ')[1],
-                                                 wallet=WALLET)
-    elif row_dict['Type'] in ("Sent assets to staking", "Market"):
-        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
-                                                 data_row.timestamp,
-                                                 sell_quantity=row_dict['Amount'].split(' ')[0],
-                                                 sell_asset=row_dict['Amount'].split(' ')[1],
-                                                 buy_quantity="0",
-                                                 buy_asset="GBP",
-                                                 wallet=WALLET)
-    elif row_dict['Type'] in ("Credited with staked assets", "Market"):
-        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
-                                                 data_row.timestamp,
-                                                 buy_quantity=row_dict['Amount'].split(' ')[0],
-                                                 buy_asset=row_dict['Amount'].split(' ')[1],
-                                                 sell_quantity="0",
-                                                 sell_asset="GBP",
-                                                 wallet=WALLET)
-    elif row_dict['Type'] in ("Staking reward", "Market"):
-        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_STAKING,
-                                                 data_row.timestamp,
-                                                 buy_quantity=row_dict['Amount'].split(' ')[0],
-                                                 buy_asset=row_dict['Amount'].split(' ')[1],
-                                                 wallet=WALLET)
     elif row_dict['Type'] == "Market":
         if row_dict['Fee']:
             fee_quantity = row_dict['Fee'].split(' ')[0]

--- a/bittytax/conv/parsers/bitstamp.py
+++ b/bittytax/conv/parsers/bitstamp.py
@@ -23,6 +23,34 @@ def parse_bitstamp(data_row, parser, **_kwargs):
                                                  sell_quantity=row_dict['Amount'].split(' ')[0],
                                                  sell_asset=row_dict['Amount'].split(' ')[1],
                                                  wallet=WALLET)
+    elif row_dict['Type'] in ("Staking", "Staking"):
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_STAKING,
+                                                 data_row.timestamp,
+                                                 sell_quantity=row_dict['Amount'].split(' ')[0],
+                                                 sell_asset=row_dict['Amount'].split(' ')[1],
+                                                 wallet=WALLET)
+    elif row_dict['Type'] in ("Sent assets to staking", "Market"):
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
+                                                 data_row.timestamp,
+                                                 sell_quantity=row_dict['Amount'].split(' ')[0],
+                                                 sell_asset=row_dict['Amount'].split(' ')[1],
+                                                 buy_quantity="0",
+                                                 buy_asset="GBP",
+                                                 wallet=WALLET)
+    elif row_dict['Type'] in ("Credited with staked assets", "Market"):
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_TRADE,
+                                                 data_row.timestamp,
+                                                 buy_quantity=row_dict['Amount'].split(' ')[0],
+                                                 buy_asset=row_dict['Amount'].split(' ')[1],
+                                                 sell_quantity="0",
+                                                 sell_asset="GBP",
+                                                 wallet=WALLET)
+    elif row_dict['Type'] in ("Staking reward", "Market"):
+        data_row.t_record = TransactionOutRecord(TransactionOutRecord.TYPE_STAKING,
+                                                 data_row.timestamp,
+                                                 buy_quantity=row_dict['Amount'].split(' ')[0],
+                                                 buy_asset=row_dict['Amount'].split(' ')[1],
+                                                 wallet=WALLET)
     elif row_dict['Type'] == "Market":
         if row_dict['Fee']:
             fee_quantity = row_dict['Fee'].split(' ')[0]


### PR DESCRIPTION
I'm not sure of the best way to associate link the Asset Sent / Credited entries from bitstamp's transaction history, I have instead give both entries a default value of 0. 

Any thoughts or objections to doing it this way?