### PR TITLE
Fix date formatting when price data is missing

### DIFF
--- a/src/bittytax/price/valueasset.py
+++ b/src/bittytax/price/valueasset.py
@@ -85,7 +85,7 @@ class ValueAsset:
 
         if not self.price_tool and timestamp.date() >= datetime.now().date():
             tqdm.write(
-                f"{WARNING} Price for {asset} on {timestamp:Y-%m-%d}, no historic price available, "
+                f"{WARNING} Price for {asset} on {timestamp:%Y-%m-%d}, no historic price available, "
                 f"using latest price"
             )
             return self.get_latest_price(asset)

--- a/src/bittytax/price/valueasset.py
+++ b/src/bittytax/price/valueasset.py
@@ -85,8 +85,8 @@ class ValueAsset:
 
         if not self.price_tool and timestamp.date() >= datetime.now().date():
             tqdm.write(
-                f"{WARNING} Price for {asset} on {timestamp:%Y-%m-%d}, no historic price available, "
-                f"using latest price"
+                f"{WARNING} Price for {asset} on {timestamp:%Y-%m-%d}, "
+                f"no historic price available, using latest price"
             )
             return self.get_latest_price(asset)
 


### PR DESCRIPTION
Before:

```
WARNING Price for ETH on Y-01-23, no historic price available, using latest price
```

After:

```
WARNING Price for ETH on 2024-01-23, no historic price available, using latest price
```