### PR TITLE
Bitstamp Parser: Updated Parser to allow for new RFC4180 header

### DIFF
--- a/src/bittytax/conv/parsers/bitstamp.py
+++ b/src/bittytax/conv/parsers/bitstamp.py
@@ -167,7 +167,8 @@ DataParser(
 DataParser(
     ParserType.EXCHANGE,
     "Bitstamp",
-    ["ID", "Account", "Type", "Subtype", "Datetime", "Amount", "Amount currency", "Value", "Value currency", "Rate", "Rate currency", "Fee", "Fee currency", "Order ID" ],
+    ["ID", "Account", "Type", "Subtype", "Datetime", "Amount", "Amount currency", "Value",
+     "Value currency", "Rate", "Rate currency", "Fee", "Fee currency", "Order ID" ],
     worksheet_name="Bitstamp",
     row_handler=parse_bitstamp_rfc4180,
 )

--- a/src/bittytax/conv/parsers/bitstamp.py
+++ b/src/bittytax/conv/parsers/bitstamp.py
@@ -114,11 +114,12 @@ def parse_bitstamp_rfc4180(data_row: "DataRow", parser: DataParser, **_kwargs: U
         )
     elif row_dict["Type"] == "Market":
         if row_dict["Fee"]:
-            fee_quantity = Decimal(row_dict["Fee"]),
-            fee_asset = row_dict["Fee currency"],
+            fee_quantity = Decimal(row_dict["Fee"])
+            fee_asset = row_dict["Fee currency"]
         else:
             fee_quantity = None
             fee_asset = ""
+
 
         if row_dict["Subtype"] == "Buy":
             data_row.t_record = TransactionOutRecord(

--- a/src/bittytax/conv/parsers/bitstamp.py
+++ b/src/bittytax/conv/parsers/bitstamp.py
@@ -84,6 +84,72 @@ def parse_bitstamp(data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[Pa
     else:
         raise UnexpectedTypeError(parser.in_header.index("Type"), "Type", row_dict["Type"])
 
+def parse_bitstamp_rfc4180(data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[ParserArgs]) -> None:
+    row_dict = data_row.row_dict
+    data_row.timestamp = DataParser.parse_timestamp(row_dict["Datetime"])
+
+    if row_dict["Type"] in ("Ripple deposit", "Deposit"):
+        data_row.t_record = TransactionOutRecord(
+            TrType.DEPOSIT,
+            data_row.timestamp,
+            buy_quantity=Decimal(row_dict["Amount"]),
+            buy_asset=row_dict["Amount currency"],
+            wallet=WALLET,
+        )
+    elif row_dict["Type"] in ("Ripple payment", "Withdrawal"):
+        data_row.t_record = TransactionOutRecord(
+            TrType.WITHDRAWAL,
+            data_row.timestamp,
+            sell_quantity=Decimal(row_dict["Amount"]),
+            sell_asset=row_dict["Amount currency"],
+            wallet=WALLET,
+        )
+    elif row_dict["Type"] == "Staking reward":
+        data_row.t_record = TransactionOutRecord(
+            TrType.STAKING,
+            data_row.timestamp,
+            buy_quantity=Decimal(row_dict["Amount"]),
+            buy_asset=row_dict["Amount currency"],
+            wallet=WALLET,
+        )
+    elif row_dict["Type"] == "Market":
+        if row_dict["Fee"]:
+            fee_quantity = Decimal(row_dict["Fee"]),
+            fee_asset = row_dict["Fee currency"],
+        else:
+            fee_quantity = None
+            fee_asset = ""
+
+        if row_dict["Subtype"] == "Buy":
+            data_row.t_record = TransactionOutRecord(
+                TrType.TRADE,
+                data_row.timestamp,
+                buy_quantity=Decimal(row_dict["Amount"]),
+                buy_asset=row_dict["Amount currency"],
+                sell_quantity=Decimal(row_dict["Amount"]),
+                sell_asset=row_dict["Amount currency"],
+                fee_quantity=fee_quantity,
+                fee_asset=fee_asset,
+                wallet=WALLET,
+            )
+        elif row_dict["Subtype"] == "Sell":
+            data_row.t_record = TransactionOutRecord(
+                TrType.TRADE,
+                data_row.timestamp,
+                buy_quantity=Decimal(row_dict["Amount"]),
+                buy_asset=row_dict["Amount currency"],
+                sell_quantity=Decimal(row_dict["Amount"]),
+                sell_asset=row_dict["Amount currency"],
+                fee_quantity=fee_quantity,
+                fee_asset=fee_asset,
+                wallet=WALLET,
+            )
+        else:
+            raise UnexpectedTypeError(
+                parser.in_header.index("Subtype"), "Sub Type", row_dict["Subtype"]
+            )
+    else:
+        raise UnexpectedTypeError(parser.in_header.index("Type"), "Type", row_dict["Type"])
 
 DataParser(
     ParserType.EXCHANGE,
@@ -92,3 +158,14 @@ DataParser(
     worksheet_name="Bitstamp",
     row_handler=parse_bitstamp,
 )
+
+DataParser(
+    ParserType.EXCHANGE,
+    "Bitstamp",
+    ["ID", "Account", "Type", "Subtype", "Datetime", "Amount", "Amount currency", "Value", "Value currency", "Rate", "Rate currency", "Fee", "Fee currency", "Order ID" ],
+    worksheet_name="Bitstamp",
+    row_handler=parse_bitstamp_rfc4180,
+)
+
+
+

--- a/src/bittytax/conv/parsers/bitstamp.py
+++ b/src/bittytax/conv/parsers/bitstamp.py
@@ -85,7 +85,8 @@ def parse_bitstamp(data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[Pa
         raise UnexpectedTypeError(parser.in_header.index("Type"), "Type", row_dict["Type"])
 
 
-def parse_bitstamp_rfc4180(data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[ParserArgs]) -> None:
+def parse_bitstamp_rfc4180(data_row: "DataRow", parser: DataParser,
+                           **_kwargs: Unpack[ParserArgs]) -> None:
     row_dict = data_row.row_dict
     data_row.timestamp = DataParser.parse_timestamp(row_dict["Datetime"])
 
@@ -170,6 +171,3 @@ DataParser(
     worksheet_name="Bitstamp",
     row_handler=parse_bitstamp_rfc4180,
 )
-
-
-

--- a/src/bittytax/conv/parsers/bitstamp.py
+++ b/src/bittytax/conv/parsers/bitstamp.py
@@ -84,6 +84,7 @@ def parse_bitstamp(data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[Pa
     else:
         raise UnexpectedTypeError(parser.in_header.index("Type"), "Type", row_dict["Type"])
 
+
 def parse_bitstamp_rfc4180(data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[ParserArgs]) -> None:
     row_dict = data_row.row_dict
     data_row.timestamp = DataParser.parse_timestamp(row_dict["Datetime"])
@@ -112,6 +113,8 @@ def parse_bitstamp_rfc4180(data_row: "DataRow", parser: DataParser, **_kwargs: U
             buy_asset=row_dict["Amount currency"],
             wallet=WALLET,
         )
+
+
     elif row_dict["Type"] == "Market":
         if row_dict["Fee"]:
             fee_quantity = Decimal(row_dict["Fee"])


### PR DESCRIPTION
Bitstamp are phasing out their old csv format of transaction history (currently both can still be generated, but the website mentions the old format will be phased out)

> Updated CSV format
> In December 2023, we upgraded the CSV file format for transaction exports to comply with the RFC 4180 standard, ensuring improved data consistency and compatibility. To generate CSV files in the previous format, you can select "Old format" during the export process. However, please be aware that this option will be removed in the coming months.