### PR TITLE
Features/lifo Features/crypto2crypto Features/yearlyHoldingReport

### DIFF
--- a/src/bittytax/bittytax.py
+++ b/src/bittytax/bittytax.py
@@ -284,7 +284,14 @@ def _do_tax(
     tax = TaxCalculator(transaction_history.transactions, tax_rules)
 
     tax.order_transactions()
-    tax.fifo_match()
+
+    if config.matching_method == "FIFO":
+        tax.fifo_match()
+    elif config.matching_method == "LIFO":
+        tax.lifo_match()
+    else:
+        raise ValueError(f"Invalid matching method: {config.matching_method}")
+
     if not tax.match_missing:
         tax.process_holdings()
 

--- a/src/bittytax/bittytax.py
+++ b/src/bittytax/bittytax.py
@@ -7,7 +7,7 @@ import io
 import os
 import platform
 import sys
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 import colorama
 from colorama import Fore
@@ -202,7 +202,7 @@ def main() -> None:
             parser.exit(message=f"{ERROR} {e}\n")
 
         if args.nopdf:
-            ReportLog(args, audit, tax.tax_report, value_asset.price_report, tax.holdings_report)
+            ReportLog(args, audit, tax.tax_report, value_asset.price_report, tax.holdings_report, tax.yearly_holdings_report)
         else:
             if args.format == ACCT_FORMAT_PDF:
                 ReportPdf(
@@ -212,6 +212,7 @@ def main() -> None:
                     tax.tax_report,
                     value_asset.price_report,
                     tax.holdings_report,
+                    tax.yearly_holdings_report,
                 )
             elif args.format == ACCT_FORMAT_EXCEL:
                 ReportExcel(
@@ -276,7 +277,7 @@ def _do_import(filename: str) -> List[TransactionRecord]:
 
 
 def _do_tax(
-    transaction_records: List[TransactionRecord], tax_rules: str
+    transaction_records: List[TransactionRecord], tax_rules: str, tax_year: Optional[Year] = None,
 ) -> Tuple[TaxCalculator, ValueAsset]:
     value_asset = ValueAsset()
     transaction_history = TransactionHistory(transaction_records, value_asset)
@@ -293,7 +294,7 @@ def _do_tax(
         raise ValueError(f"Invalid matching method: {config.matching_method}")
 
     if not tax.match_missing:
-        tax.process_holdings()
+        tax.process_holdings(tax_year)
 
     return tax, value_asset
 
@@ -348,6 +349,9 @@ def _do_each_tax_year(
             "Income": calc_income,
             "MarginTrading": calc_margin_trading,
         }
+
+        if not summary_only:
+            tax.calculate_yearly_holdings(value_asset, tax_year)
     else:
         # Calculate for all years
         for year in sorted(tax.tax_events):
@@ -362,11 +366,13 @@ def _do_each_tax_year(
                     "Income": calc_income,
                     "MarginTrading": calc_margin_trading,
                 }
+
             else:
                 print(f"{WARNING} Tax year {year} is not supported")
 
         if not summary_only:
             tax.calculate_holdings(value_asset)
+            tax.calculate_yearly_holdings(value_asset)
 
 
 def _do_export(transaction_records: List[TransactionRecord]) -> None:

--- a/src/bittytax/bt_types.py
+++ b/src/bittytax/bt_types.py
@@ -36,6 +36,7 @@ class TrType(Enum):
     MARGIN_FEE = "Margin-Fee"
     TRADE = "Trade"
     SWAP = "Swap"
+    CRYPTO_CRYPTO = 'crypto-crypto'
 
 
 class DisposalType(Enum):
@@ -74,6 +75,7 @@ BUY_TYPES = (
     TrType.MARGIN_GAIN,
     TrType.TRADE,
     TrType.SWAP,
+    TrType.CRYPTO_CRYPTO,
 )
 
 SELL_TYPES = (
@@ -90,6 +92,7 @@ SELL_TYPES = (
     TrType.MARGIN_FEE,
     TrType.TRADE,
     TrType.SWAP,
+    TrType.CRYPTO_CRYPTO,
 )
 
 BUY_AND_SELL_TYPES = [t for t in BUY_TYPES if t in SELL_TYPES]

--- a/src/bittytax/config.py
+++ b/src/bittytax/config.py
@@ -19,6 +19,7 @@ class Config:
 
     FIAT_LIST = ["GBP", "EUR", "USD", "AUD", "NZD", "CAD", "PLN"]
     CRYPTO_LIST = ["BTC", "ETH", "XRP", "LTC", "BCH", "USDT"]
+    STABLECOIN_LIST = ["USDT", "USDC", "DAI"]
 
     TRADE_ASSET_TYPE_BUY = 0
     TRADE_ASSET_TYPE_SELL = 1
@@ -58,6 +59,8 @@ class Config:
         "coinbase_zero_fees_are_gifts": False,
         "binance_multi_bnb_split_even": False,
         "binance_statements_only": False,
+        "stablecoin_list": STABLECOIN_LIST,
+        "is_crypto2crypto_taxable": False,
     }
 
     OPTIONAL_CONFIG = (

--- a/src/bittytax/config.py
+++ b/src/bittytax/config.py
@@ -60,7 +60,7 @@ class Config:
         "binance_multi_bnb_split_even": False,
         "binance_statements_only": False,
         "stablecoin_list": STABLECOIN_LIST,
-        "is_crypto2crypto_taxable": False,
+        "is_crypto2crypto_taxable": True,
     }
 
     OPTIONAL_CONFIG = (

--- a/src/bittytax/config.py
+++ b/src/bittytax/config.py
@@ -61,6 +61,7 @@ class Config:
         "binance_statements_only": False,
         "stablecoin_list": STABLECOIN_LIST,
         "is_crypto2crypto_taxable": True,
+        "matching_method": "FIFO", # user can choose between 'FIFO' or 'LIFO'
     }
 
     OPTIONAL_CONFIG = (

--- a/src/bittytax/config/bittytax.conf
+++ b/src/bittytax/config/bittytax.conf
@@ -92,4 +92,4 @@ binance_multi_bnb_split_even: False
 binance_statements_only: False
 
 # Use is_crypto2crypto_taxable to determine if crypto-to-crypto trades are taxable (Crypto-to-Stablecoin trades is always a taxable events)
-is_crypto2crypto_taxable: False
+is_crypto2crypto_taxable: True

--- a/src/bittytax/config/bittytax.conf
+++ b/src/bittytax/config/bittytax.conf
@@ -90,3 +90,6 @@ binance_multi_bnb_split_even: False
 
 # Use Binance statements for ALL transaction types
 binance_statements_only: False
+
+# Use is_crypto2crypto_taxable to determine if crypto-to-crypto trades are taxable (Crypto-to-Stablecoin trades is always a taxable events)
+is_crypto2crypto_taxable: False

--- a/src/bittytax/config/bittytax.conf
+++ b/src/bittytax/config/bittytax.conf
@@ -93,3 +93,6 @@ binance_statements_only: False
 
 # Use is_crypto2crypto_taxable to determine if crypto-to-crypto trades are taxable (Crypto-to-Stablecoin trades is always a taxable events)
 is_crypto2crypto_taxable: True
+
+# User can choose which method to use for tax calculations between 'FIFO' or 'LIFO'
+matching_method: 'FIFO'

--- a/src/bittytax/holdings.py
+++ b/src/bittytax/holdings.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 # (c) Nano Nano Ltd 2019
 
+from bisect import bisect_right
 from decimal import Decimal
 
+from datetime import datetime, timedelta
 from colorama import Fore
 from tqdm import tqdm
 
 from .bt_types import AssetSymbol
 from .config import config
 from .constants import WARNING
+
 
 
 class Holdings:
@@ -20,11 +23,32 @@ class Holdings:
         self.withdrawals = 0
         self.deposits = 0
         self.mismatches = 0
+        self.balance_history = [(None, Decimal(0))]
+        self.cost_history = [(None, Decimal(0))]
 
-    def add_tokens(self, quantity: Decimal, cost: Decimal, fees: Decimal, is_deposit: bool) -> None:
+    def _addto_balance_history(self, quantity: Decimal, transaction_date: datetime) -> None:
+        last_balance = self.balance_history[-1][1]
+        new_balance = last_balance + quantity
+        self._update_balance_history(new_balance, transaction_date)
+
+    def _subctractto_balance_history(self, quantity: Decimal, transaction_date: datetime) -> None:
+        last_balance = self.balance_history[-1][1]
+        new_balance = last_balance - quantity
+        self._update_balance_history(new_balance, transaction_date)
+
+    def _update_balance_history(self, new_balance: Decimal, transaction_date: datetime) -> None:
+        if self.balance_history[-1][0] is None:
+            self.balance_history[-1] = (transaction_date.date(), new_balance)
+        else:
+            last_balance = self.balance_history[-1][1]
+            if new_balance != last_balance:
+                self.balance_history.append((transaction_date.date(), new_balance))
+
+    def add_tokens(self, quantity: Decimal, cost: Decimal, fees: Decimal, is_deposit: bool, transaction_date: datetime) -> None:
         self.quantity += quantity
         self.cost += cost
         self.fees += fees
+        self._addto_balance_history(quantity, transaction_date) 
 
         if is_deposit:
             self.deposits += 1
@@ -40,11 +64,12 @@ class Holdings:
             )
 
     def subtract_tokens(
-        self, quantity: Decimal, cost: Decimal, fees: Decimal, is_withdrawal: bool
+        self, quantity: Decimal, cost: Decimal, fees: Decimal, is_withdrawal: bool, transaction_date: datetime
     ) -> None:
         self.quantity -= quantity
         self.cost -= cost
         self.fees -= fees
+        self._subctractto_balance_history(quantity, transaction_date) 
 
         if is_withdrawal:
             self.withdrawals += 1
@@ -66,3 +91,58 @@ class Holdings:
                 f"({self.withdrawals}:{self.deposits}) for {self.asset}, cost basis will be wrong"
             )
             self.mismatches += 1
+
+    def get_balance_at_date(self, target_date: datetime.date) -> Decimal:
+        dates = [date for date, balance in self.balance_history]
+        pos = bisect_right(dates, target_date) - 1  # Find the index closest to the target_date
+        if pos >= 0:
+            return self.balance_history[pos][1]  # Returns the corresponding balance
+        return Decimal(0)
+
+    def calculate_average_balance(self, start_date: datetime.date, end_date: datetime.date) -> Decimal:
+        total_balance = Decimal(0)
+        day_count = 0
+
+        # Extract balance_history for convenience
+        balance_history = self.balance_history
+        balance_history_len = len(balance_history)
+
+        # If there is no historical data, return 0 immediately
+        if balance_history_len == 0:
+            return Decimal(0)
+
+        # We start with a balance of 0 until we reach the first available date
+        current_date = start_date
+        previous_balance = Decimal(0)
+
+        for i, (date, balance) in enumerate(balance_history):
+            # If the current balance date is beyond the end date, we can exit
+            if date > end_date:
+                break
+        
+            # If there are days between current_date and the current date of the balance_history
+            if date > current_date:
+                # Calculates the number of days between current_date and the current balance sheet date
+                days_in_between = (min(date, end_date) - current_date).days
+                if days_in_between > 0:
+                    total_balance += previous_balance * Decimal(days_in_between)
+                    day_count += days_in_between
+
+            # Update current_date to the latest between current balance date and start_date
+            current_date = max(current_date, date)
+            previous_balance = balance
+
+            # If we are past end_date, we can finish
+            if current_date > end_date:
+                break
+
+        # If there are still days remaining between current_date and end_date, add the final balance
+        if current_date <= end_date:
+            days_in_between = (end_date - current_date).days + 1
+            total_balance += previous_balance * Decimal(days_in_between)
+            day_count += days_in_between
+
+        # Calculating the average if there are days counted
+        if day_count > 0:
+            return total_balance / Decimal(day_count)
+        return Decimal(0)

--- a/src/bittytax/tax.py
+++ b/src/bittytax/tax.py
@@ -271,6 +271,120 @@ class TaxCalculator:  # pylint: disable=too-many-instance-attributes
                 s.matched = True
                 self._create_disposal(s, matches)
 
+    def lifo_match(self) -> None:
+        # Fai una copia delle transazioni per un eventuale uso futuro (tassazione o altro)
+        self.transactions = copy.deepcopy(self.transactions)
+
+        if config.debug:
+            print(f"{Fore.CYAN}lifo match transactions")
+
+        buy_index = {}
+
+        # Itera attraverso tutte le transazioni di vendita
+        for s in tqdm(
+            self.sells_ordered,
+            unit="t",
+            desc=f"{Fore.CYAN}lifo match transactions{Fore.GREEN}",
+            disable=bool(config.debug or not sys.stdout.isatty()),
+        ):
+            matches = []
+            s_quantity_remaining = s.quantity
+
+            if config.debug:
+                print(f"{Fore.GREEN}lifo: Analizzando vendita: {s}")
+                print(f"{Fore.GREEN}lifo: Quantità vendita rimanente: {s_quantity_remaining}")
+
+            if s.asset in self.buys_ordered:
+                # Trova l'indice del primo acquisto che avviene **prima** della vendita e non è già stato abbinato
+                for i in reversed(range(len(self.buys_ordered[s.asset]))):
+                    if self.buys_ordered[s.asset][i].date() <= s.date() and not self.buys_ordered[s.asset][i].matched:
+                        buy_index[s.asset] = i
+                        break
+                else:
+                    buy_index[s.asset] = -1  # Nessun acquisto disponibile prima della vendita
+
+            if config.debug:
+                if s.asset in buy_index and buy_index[s.asset] != -1:
+                    print(f"{Fore.YELLOW}lifo: Inizializzazione buy_index per {s.asset}: {buy_index[s.asset]}")
+                    print(f"{Fore.YELLOW}lifo: Transazioni di acquisto disponibili per {s.asset}: {len(self.buys_ordered[s.asset])}")
+                else:
+                    print(f"{Fore.RED}lifo: Nessun acquisto valido trovato per {s.asset} prima della vendita")
+
+            while (
+                s.asset in self.buys_ordered
+                and buy_index[s.asset] >= 0
+                and s_quantity_remaining > 0
+            ):
+                b = self.buys_ordered[s.asset][buy_index[s.asset]]
+
+                if config.debug:
+                    print(f"{Fore.BLUE}lifo: Considerando acquisto {b}")
+                    print(f"{Fore.BLUE}lifo: Quantità acquisto: {b.quantity}, Data acquisto: {b.date()}, Data vendita: {s.date()}")
+
+                if b.date() > s.date():
+                    if config.debug:
+                        print(f"{Fore.RED}lifo: L'acquisto {b} è successivo alla vendita {s}. Interrompo l'abbinamento.")
+                    break
+
+                # Controlla se l'acquisto è già stato abbinato a una vendita precedente
+                if b.matched:
+                    if config.debug:
+                        print(f"{Fore.RED}lifo: L'acquisto {b} è già stato usato. Passo al prossimo.")
+                    buy_index[s.asset] -= 1
+                    continue
+
+                if b.quantity > s_quantity_remaining:
+                    # Se la quantità acquistata è maggiore della quantità da vendere, splitta l'acquisto
+                    b_remainder = b.split_buy(s_quantity_remaining)
+                    self.buys_ordered[s.asset].insert(buy_index[s.asset] + 1, b_remainder)
+
+                    if config.debug:
+                        print(f"{Fore.GREEN}lifo: Split dell'acquisto {b}. Nuovo acquisto {b_remainder} creato con quantità {b_remainder.quantity}")
+                        print(f"{Fore.YELLOW}lifo: Acquisto aggiornato: {b}, Quantità rimanente: {b.quantity}")
+
+                else:
+                    if config.debug:
+                        print(f"{Fore.GREEN}lifo: Abbinamento completo per acquisto {b}")
+
+                b.matched = True  # Segna l'acquisto come abbinato
+                matches.append(b)
+                s_quantity_remaining -= b.quantity
+
+                if config.debug:
+                    print(f"{Fore.GREEN}lifo: Quantità vendita rimanente dopo abbinamento: {s_quantity_remaining}")
+
+                # Spostati all'acquisto precedente
+                buy_index[s.asset] -= 1
+
+                if config.debug:
+                    print(f"{Fore.YELLOW}lifo: Nuovo buy_index per {s.asset}: {buy_index[s.asset]}")
+
+            if s_quantity_remaining > 0:
+                tqdm.write(
+                    f"{WARNING} No matching Buy of {s_quantity_remaining.normalize():0,f} "
+                    f"{s.asset} per la vendita di {s.format_quantity()} {s.asset}"
+                )
+                if config.debug:
+                    print(f"{Fore.RED}lifo: Nessun acquisto corrispondente trovato per {s_quantity_remaining} di {s.asset}")
+                if config.cost_basis_zero_if_missing:
+                    buy_match = Buy(TrType.TRADE, s_quantity_remaining, s.asset, Decimal(0))
+                    buy_match.wallet = s.wallet
+                    buy_match.timestamp = s.timestamp
+                    buy_match.note = Note("Aggiunto come costo zero")
+                    tqdm.write(f"{Fore.GREEN}lifo: {buy_match}")
+                    matches.append(buy_match)
+                    s.matched = True
+                    self._create_disposal(s, matches)
+                else:
+                    self.match_missing = True
+            else:
+                s.matched = True
+                self._create_disposal(s, matches)
+
+            if config.debug:
+                print(f"{Fore.GREEN}lifo: Vendita completata: {s}")
+                print(f"{Fore.GREEN}lifo: Matches trovati: {matches}")
+
     def _create_disposal(self, sell: Sell, matches: List[Buy]) -> None:
         short_term = BuyAccumulator()
         long_term = BuyAccumulator()

--- a/src/bittytax/tax.py
+++ b/src/bittytax/tax.py
@@ -153,6 +153,7 @@ class TaxCalculator:  # pylint: disable=too-many-instance-attributes
         TrType.CHARITY_SENT,
         TrType.LOST,
         TrType.SWAP,
+        TrType.CRYPTO_CRYPTO,
     )
 
     MARGIN_TYPES = (TrType.MARGIN_GAIN, TrType.MARGIN_LOSS, TrType.MARGIN_FEE)
@@ -369,14 +370,14 @@ class TaxCalculator:  # pylint: disable=too-many-instance-attributes
             if config.debug:
                 print(f"{Fore.CYAN}fifo: {tax_event}")
 
-        if sell.t_type is TrType.SWAP:
+        if sell.t_type in (TrType.SWAP, TrType.CRYPTO_CRYPTO):
             # Cost basis copied to "Buy" asset
             if sell.t_record and sell.t_record.buy:
                 sell.t_record.buy.cost = short_term.cost + long_term.cost
                 if short_term.fee_value + long_term.fee_value:
                     sell.t_record.buy.fee_value = short_term.fee_value + long_term.fee_value
             else:
-                raise RuntimeError("Missing t_record.buy for SWAP")
+                raise RuntimeError("Missing t_record.buy for SWAP/CRYPTO_CRYPTO")
 
     def process_holdings(self) -> None:
         if config.debug:

--- a/src/bittytax/templates/cover_page.html
+++ b/src/bittytax/templates/cover_page.html
@@ -2,6 +2,7 @@
     <img src="{{TEMPLATE_PATH}}/img/BittyTax300dpi.png" class="logo">
     <h1>Cryptoasset Accounting Report</h1>
     <h2>US Individual Tax Rules</h2>
+    <p><strong>Calculation Method Used:</strong> {{ config.matching_method }}</p>
     {% if args.tax_year %}
         <h3>Tax Year: {{config.format_tax_year(args.tax_year)}}</h3>
     {% else %}

--- a/src/bittytax/templates/holdings.html
+++ b/src/bittytax/templates/holdings.html
@@ -33,7 +33,7 @@
 <table class="total-table">
     <tr>
         <td align="left">Total</td>
-        <td align="left""></td>
+        <td align="left"></td>
         <td align="right">{{holdings_report['totals']['cost']|valuefilter}}</td>
         <td align="right">{{holdings_report['totals']['value']|valuefilter}}</td>
         {% if holdings_report['totals']['gain'] >= 0 %}

--- a/src/bittytax/templates/tax_full_report.html
+++ b/src/bittytax/templates/tax_full_report.html
@@ -36,6 +36,10 @@
                 <pdf:nextpage />
             {% endif %}
         {% endfor %}
+        {% if yearly_holdings_report %}
+           <pdf:nextpage />
+           {% include "yearly_holdings.html" %}
+        {% endif %}
         {% if holdings_report %}
            <pdf:nextpage />
            {% include "holdings.html" %}

--- a/src/bittytax/templates/yearly_holdings.html
+++ b/src/bittytax/templates/yearly_holdings.html
@@ -1,0 +1,36 @@
+<h1>Yearly Holdings</h1>
+{% for tax_year, report in yearly_holdings_report.items() %}
+<h2>{{ config.format_tax_year(tax_year) }}</h2>
+<table repeat="1" width="100%" class="asset-table">
+    <thead>
+        <tr>
+            <th align="left">Asset</th>
+            <th align="right">Quantity at End of Year</th>
+            <th align="right">Average Balance</th>
+            <th align="right">Value in Fiat at End of Year</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for asset_symbol, asset_data in report.assets.items() %}
+        <tr>
+            <td align="left">{{ asset_symbol }}</td>
+            <td align="right">{{ asset_data.quantity_end_of_year | format_decimal }}</td>
+            <td align="right">{{ asset_data.average_balance | format_decimal }}</td>
+            {% if asset_data.value_in_fiat_at_end_of_year is not none %}
+            <td align="right">{{ asset_data.value_in_fiat_at_end_of_year | valuefilter }}</td>
+            {% else %}
+            <td align="right"><i>Not available</i></td>
+            {% endif %}
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+<table class="total-table">
+    <tr>
+        <td align="left"><strong>Total</strong></td>
+        <td></td>
+        <td></td>
+        <td align="right"><strong>{{ report.totals.total_value_in_fiat_at_end_of_year | valuefilter }}</strong></td>
+    </tr>
+</table>
+{% endfor %}

--- a/src/bittytax/transactions.py
+++ b/src/bittytax/transactions.py
@@ -37,10 +37,20 @@ class TransactionHistory:
 
             self.get_all_values(tr)
 
+            if tr.t_type == TrType.TRADE and tr.buy and tr.sell:
+                if tr.sell.asset not in config.fiat_list and tr.buy.asset not in config.fiat_list:
+                    if tr.sell.asset not in config.stablecoin_list and tr.buy.asset not in config.stablecoin_list:
+                        if not config.is_crypto2crypto_taxable:
+                            tr.t_type = TrType.CRYPTO_CRYPTO
+                            if tr.buy:
+                                tr.buy.t_type = TrType.CRYPTO_CRYPTO
+                            if tr.sell:
+                                tr.sell.t_type = TrType.CRYPTO_CRYPTO
+
             # The fee value (trading fee) as an allowable cost to the buy, the sell or both
             if tr.fee and tr.fee.disposal and tr.fee.proceeds:
                 if tr.buy and tr.buy.acquisition and tr.sell and tr.sell.disposal:
-                    if tr.t_type in (TrType.TRADE, TrType.SWAP):
+                    if tr.t_type in (TrType.TRADE, TrType.SWAP, TrType.CRYPTO_CRYPTO):
                         if tr.buy.asset in config.fiat_list:
                             tr.sell.fee_value = tr.fee.proceeds
                             tr.sell.fee_fixed = tr.fee.proceeds_fixed
@@ -341,6 +351,7 @@ class Buy(TransactionBase):  # pylint: disable=too-many-instance-attributes
         TrType.MARGIN_GAIN,
         TrType.TRADE,
         TrType.SWAP,
+        TrType.CRYPTO_CRYPTO,
     }
 
     def __init__(
@@ -464,6 +475,7 @@ class Sell(TransactionBase):  # pylint: disable=too-many-instance-attributes
         TrType.MARGIN_FEE,
         TrType.TRADE,
         TrType.SWAP,
+        TrType.CRYPTO_CRYPTO,
     }
 
     def __init__(


### PR DESCRIPTION
this merge introduces 3 new features:
- lifo
- crypto2crypto
- yearly holding report

With "lifo" the Lifo method is added to the existing logic for processing taxes with the Fifo method.

With "crypto2crypto" the possibility of excluding crypto to crypto transactions from the tax calculation that are equated to the swap is added.

With "yearly holding report" a new section is added to the full report with the printing of the holdings status at the end of the fiscal year for all the years considered. The current holdings remains active as before.
also now it is possible to pass the year as a parameter for the holdings.

All these functions are necessary for the Italian branch.

I am not fully convinced by the implementation of "yearly holding report" that in my Italian branch has already been partially modified with the addition of details and the refactoring of the report to better adapt to the needs of the Italian market.