### PR TITLE
Fix "--cryptoasset" argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 - Accounting/Price tool: added CryptoCompare asset IDs to allow custom mapping of asset symbols.
 - BlockFi parser: added "BIA Deposit" transaction type.
 - Config: added USDC to crypto_list.
+- Conversion tool: added (--cryptoasset) option.
 ### Changed
 - Conversion tool: openpyxl use read-only mode. ([#337](https://github.com/BittyTax/BittyTax/issues/337))
 - Accounting tool: openpyxl use read-only mode. ([#337](https://github.com/BittyTax/BittyTax/issues/337))

--- a/src/bittytax/conv/bittytax_conv.py
+++ b/src/bittytax/conv/bittytax_conv.py
@@ -57,7 +57,7 @@ def main() -> None:
     )
     parser.add_argument(
         "-ca",
-        dest="cryptoasset",
+        "--cryptoasset",
         type=str,
         help="specify a cryptoasset symbol, if it cannot be identified automatically",
     )


### PR DESCRIPTION
The docs say "-ca or --cryptoasset argument can be used ..." but "--cryptoasset" doesn't work. This change should fix that