### PR TITLE
Add Operation "Margin Loan" to Binance parser

### DIFF
--- a/src/bittytax/conv/parsers/binance.py
+++ b/src/bittytax/conv/parsers/binance.py
@@ -691,7 +691,7 @@ def _parse_binance_statements_margin_row(
 ) -> None:
     row_dict = data_row.row_dict
 
-    if row_dict["Operation"] in ("Margin Loan", "Isolated Margin Loan"):
+    if row_dict["Operation"] in ("Margin loan", "Margin Loan", "Isolated Margin Loan"):
         data_row.t_record = TransactionOutRecord(
             TrType.LOAN,
             data_row.timestamp,

--- a/src/bittytax/conv/parsers/binance.py
+++ b/src/bittytax/conv/parsers/binance.py
@@ -691,7 +691,7 @@ def _parse_binance_statements_margin_row(
 ) -> None:
     row_dict = data_row.row_dict
 
-    if row_dict["Operation"] in ("Margin loan", "Isolated Margin Loan"):
+    if row_dict["Operation"] in ("Margin Loan", "Isolated Margin Loan"):
         data_row.t_record = TransactionOutRecord(
             TrType.LOAN,
             data_row.timestamp,


### PR DESCRIPTION
The Binance transaction record contains the operation "Margin Loan". BittyTax currently parses the case sensitive phrase "Margin loan". Consequently, the resulting BittyTax report does ignore any margin loans. This PR fixes this issue.