### PR TITLE
Added to the parsing of bitfinex deposits and withdrawals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Ledger Live parser: added "DELEGATE" and "UNDELEGATE" Operation Types.
 - Kraken parser: added "earn" subtypes "airdrop" and "autoallocation".
 - SwissBorg parser: added "Fee Adjustment" Type.
+- Bitfinex parser: added new deposits/withdrawals export format.
 ### Changed
 - Config: fiat_income to True.
 - Price tool: CoinDesk API deprecated.

--- a/src/bittytax/conv/parsers/bitfinex.py
+++ b/src/bittytax/conv/parsers/bitfinex.py
@@ -69,9 +69,11 @@ def parse_bitfinex_deposits_withdrawals(
 ) -> None:
     row_dict = data_row.row_dict
 
-    date_value = row_dict.get("DATE") or row_dict.get("UPDATED")
+    if "DATE" in row_dict:
+        row_dict["UPDATED"] = row_dict["DATE"]
+
     data_row.timestamp = DataParser.parse_timestamp(
-        date_value, dayfirst=config.date_is_day_first
+        row_dict["UPDATED"], dayfirst=config.date_is_day_first
     )
 
     data_row.tx_raw = TxRawPos(


### PR DESCRIPTION
New file parsing of bitfinix export. See sample file with STARTED and UPDATED time:
[bitfinex-export.csv](https://github.com/user-attachments/files/25023944/bitfinex-export.csv)
