### PR TITLE
Added stake related transaction types to Revolut parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Nexo parser: added new export format with `normalizedDisplayDetails` column. ([#482](https://github.com/BittyTax/BittyTax/issues/482))
 - Env: added BITTYTAX_DATA_DIR variable which specifies the location for storing the .bittytax folder.
 - Accounting tool: tax rates and allowance for 2026/27.
+- Revolut parser: added "Stake", "Unstake" and "Stake Rewards" transaction types
 ### Changed
 - Config: fiat_income to True.
 - Price tool: CoinDesk API deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Accounting tool: tax rates and allowance for 2026/27.
 - Conversion tool: added newest_first to DataParser to control the parsing order.
 - KuCoin parser: handle empty reports with "No matching records found".
-- Revolut parser: added "Staking reward" transaction type.
+- Revolut parser: added "Stake", "Unstake" and "Staking reward" transaction types.
 ### Changed
 - Config: fiat_income to True.
 - Price tool: CoinDesk API deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Accounting tool: tax rates and allowance for 2026/27.
 - Conversion tool: added newest_first to DataParser to control the parsing order.
 - KuCoin parser: handle empty reports with "No matching records found".
+- Revolut parser: added "Stake", "Unstake" and "Stake Rewards" transaction types
 ### Changed
 - Config: fiat_income to True.
 - Price tool: CoinDesk API deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Accounting tool: tax rates and allowance for 2026/27.
 - Conversion tool: added newest_first to DataParser to control the parsing order.
 - KuCoin parser: handle empty reports with "No matching records found".
-- Revolut parser: added "Stake", "Unstake" and "Stake Rewards" transaction types
+- Revolut parser: added "Staking reward" transaction type
 ### Changed
 - Config: fiat_income to True.
 - Price tool: CoinDesk API deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Accounting tool: tax rates and allowance for 2026/27.
 - Conversion tool: added newest_first to DataParser to control the parsing order.
 - KuCoin parser: handle empty reports with "No matching records found".
-- Revolut parser: added "Staking reward" transaction type
+- Revolut parser: added "Staking reward" transaction type.
 ### Changed
 - Config: fiat_income to True.
 - Price tool: CoinDesk API deprecated.

--- a/src/bittytax/conv/parsers/revolut.py
+++ b/src/bittytax/conv/parsers/revolut.py
@@ -81,6 +81,36 @@ def parse_revolut(data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[Par
             buy_asset=row_dict["Symbol"],
             wallet=WALLET,
         )
+    elif row_dict["Type"] == "Staking reward":
+        data_row.t_record = TransactionOutRecord(
+            TrType.STAKING_REWARD,
+            data_row.timestamp,
+            buy_quantity=Decimal(row_dict["Quantity"].replace(",", "")),
+            buy_asset=row_dict["Symbol"],
+            wallet=WALLET,
+        )
+    elif row_dict["Type"] == "Stake":
+        data_row.t_record = TransactionOutRecord(
+            TrType.STAKE,
+            data_row.timestamp,
+            sell_quantity=Decimal(row_dict["Quantity"].replace(",", "")),
+            sell_asset=row_dict["Symbol"],
+            sell_value=value,
+            fee_quantity=fee_value,
+            fee_asset=config.ccy,
+            wallet=WALLET,
+        )
+    elif row_dict["Type"] == "Unstake":
+        data_row.t_record = TransactionOutRecord(
+            TrType.UNSTAKE,
+            data_row.timestamp,
+            buy_quantity=Decimal(row_dict["Quantity"].replace(",", "")),
+            buy_asset=row_dict["Symbol"],
+            buy_value=value,
+            fee_quantity=fee_value,
+            fee_asset=config.ccy,
+            wallet=WALLET,
+        )        
     else:
         raise UnexpectedTypeError(parser.in_header.index("Type"), "Type", row_dict["Type"])
 

--- a/src/bittytax/conv/parsers/revolut.py
+++ b/src/bittytax/conv/parsers/revolut.py
@@ -90,27 +90,9 @@ def parse_revolut(data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[Par
             wallet=WALLET,
         )
     elif row_dict["Type"] == "Stake":
-        data_row.t_record = TransactionOutRecord(
-            TrType.STAKE,
-            data_row.timestamp,
-            sell_quantity=Decimal(row_dict["Quantity"].replace(",", "")),
-            sell_asset=row_dict["Symbol"],
-            sell_value=value,
-            fee_quantity=fee_value,
-            fee_asset=config.ccy,
-            wallet=WALLET,
-        )
+        pass
     elif row_dict["Type"] == "Unstake":
-        data_row.t_record = TransactionOutRecord(
-            TrType.UNSTAKE,
-            data_row.timestamp,
-            buy_quantity=Decimal(row_dict["Quantity"].replace(",", "")),
-            buy_asset=row_dict["Symbol"],
-            buy_value=value,
-            fee_quantity=fee_value,
-            fee_asset=config.ccy,
-            wallet=WALLET,
-        )        
+        pass
     else:
         raise UnexpectedTypeError(parser.in_header.index("Type"), "Type", row_dict["Type"])
 

--- a/src/bittytax/conv/parsers/revolut.py
+++ b/src/bittytax/conv/parsers/revolut.py
@@ -89,10 +89,9 @@ def parse_revolut(data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[Par
             buy_asset=row_dict["Symbol"],
             wallet=WALLET,
         )
-    elif row_dict["Type"] == "Stake":
-        pass
-    elif row_dict["Type"] == "Unstake":
-        pass
+    elif row_dict["Type"] in ("Stake", "Unstake"):
+        # Skip internal transfers
+        return
     else:
         raise UnexpectedTypeError(parser.in_header.index("Type"), "Type", row_dict["Type"])
 


### PR DESCRIPTION
Transaction types updated in Revolut parser. Similar operations are already implemented for other parsers.