### PR TITLE
Koinly parser: added "Bulk edit in Excel" transactions export

### DIFF
--- a/.pylint_dictionary
+++ b/.pylint_dictionary
@@ -30,6 +30,7 @@ guestimate
 hotbit
 i
 json
+koinly
 kraken
 lookups
 nano
@@ -43,6 +44,7 @@ timestamp
 timezone
 txhash
 unstake
+untagged
 url
 xlsx
 xlsxwriter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The new `price_via_btc` config option may not exist in your config file. If it i
 - Config: added CHF (Swiss franc), DKK (Danish krone), NOK (Norwegian krone) and SEK (Swedish krona) to `FIAT_LIST`, with correct currency symbols.
 - Revolut parser: added "Stake", "Unstake" and "Staking reward" transaction types.
 - KuCoin parser: added "Convert Orders_Filled Orders" from bundle files.
+- Koinly parser: added "Bulk edit in Excel" transactions export.
 ### Changed
 - Config: fiat_income to True.
 - Price tool: CoinDesk API deprecated.

--- a/src/bittytax/conv/parsers/koinly.py
+++ b/src/bittytax/conv/parsers/koinly.py
@@ -4,8 +4,9 @@
 import copy
 import re
 import sys
+from datetime import datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from colorama import Fore
 from typing_extensions import Unpack
@@ -243,4 +244,162 @@ DataParser(
     ],
     worksheet_name="Koinly",
     all_handler=parse_koinly,
+)
+
+
+# Koinly "Bulk edit in Excel" transactions export, see:
+# https://support.koinly.io/en/articles/9490043-bulk-edit-in-excel
+# One row per transaction, using From/To columns instead of the Sent/Received columns of the
+# tax report export above. The direction is taken from the populated side: "To" only is a
+# deposit, "From" only is a withdrawal, both is a trade. Currency and wallet cells carry a
+# ";<id>" suffix (e.g. "WFLR;9546698") which is removed. The Tag column drives the type for
+# deposits and withdrawals, an untagged transfer defaults to Deposit/Withdrawal.
+
+
+def _strip_koinly_id(value: str) -> str:
+    return value.split(";", 1)[0].strip()
+
+
+def _get_koinly_value(amount: str, currency: str, timestamp: datetime) -> Optional[Decimal]:
+    if amount and Decimal(amount) != 0:
+        return DataParser.convert_currency(amount, _strip_koinly_id(currency), timestamp)
+    return None
+
+
+def parse_koinly_bulk_edit(
+    data_row: "DataRow", parser: DataParser, **_kwargs: Unpack[ParserArgs]
+) -> None:
+    row_dict = data_row.row_dict
+    data_row.timestamp = DataParser.parse_timestamp(row_dict["Date (UTC)"])
+    data_row.tx_raw = TxRawPos(
+        parser.in_header.index("TxHash"),
+        parser.in_header.index("TxSrc"),
+        parser.in_header.index("TxDest"),
+    )
+
+    tag = row_dict["Tag"]
+    from_amount = row_dict["From Amount"]
+    to_amount = row_dict["To Amount"]
+    has_from = bool(from_amount) and Decimal(from_amount) != 0
+    has_to = bool(to_amount) and Decimal(to_amount) != 0
+
+    value = _get_koinly_value(
+        row_dict["Net Value (read-only)"],
+        row_dict["Value Currency (read-only)"],
+        data_row.timestamp,
+    ) or _get_koinly_value(
+        row_dict["Net Worth Amount"], row_dict["Net Worth Currency"], data_row.timestamp
+    )
+
+    if row_dict["Fee Amount"]:
+        fee_quantity = Decimal(row_dict["Fee Amount"])
+        fee_asset = _strip_koinly_id(row_dict["Fee Currency"])
+    else:
+        fee_quantity = None
+        fee_asset = ""
+
+    fee_value = _get_koinly_value(
+        row_dict["Fee Value (read-only)"],
+        row_dict["Value Currency (read-only)"],
+        data_row.timestamp,
+    ) or _get_koinly_value(
+        row_dict["Fee Worth Amount"], row_dict["Fee Worth Currency"], data_row.timestamp
+    )
+
+    if has_from and has_to:
+        data_row.t_record = TransactionOutRecord(
+            TrType.TRADE,
+            data_row.timestamp,
+            buy_quantity=Decimal(to_amount),
+            buy_asset=_strip_koinly_id(row_dict["To Currency"]),
+            buy_value=value,
+            sell_quantity=Decimal(from_amount),
+            sell_asset=_strip_koinly_id(row_dict["From Currency"]),
+            sell_value=value,
+            fee_quantity=fee_quantity,
+            fee_asset=fee_asset,
+            fee_value=fee_value,
+            wallet=_strip_koinly_id(row_dict["To Wallet (read-only)"]),
+            note=row_dict["Description"],
+        )
+    elif has_to:
+        if tag == "":
+            t_type: Union[TrType, UnmappedType] = TrType.DEPOSIT
+        else:
+            t_type = KOINLY_D_MAPPING.get(tag, UnmappedType(f"_{tag}"))
+
+        data_row.t_record = TransactionOutRecord(
+            t_type,
+            data_row.timestamp,
+            buy_quantity=Decimal(to_amount),
+            buy_asset=_strip_koinly_id(row_dict["To Currency"]),
+            buy_value=value,
+            fee_quantity=fee_quantity,
+            fee_asset=fee_asset,
+            fee_value=fee_value,
+            wallet=_strip_koinly_id(row_dict["To Wallet (read-only)"]),
+            note=row_dict["Description"],
+        )
+    elif has_from:
+        if tag == "":
+            t_type = TrType.WITHDRAWAL
+        else:
+            t_type = KOINLY_W_MAPPING.get(tag, UnmappedType(f"_{tag}"))
+
+        data_row.t_record = TransactionOutRecord(
+            t_type,
+            data_row.timestamp,
+            sell_quantity=Decimal(from_amount),
+            sell_asset=_strip_koinly_id(row_dict["From Currency"]),
+            sell_value=value,
+            fee_quantity=fee_quantity,
+            fee_asset=fee_asset,
+            fee_value=fee_value,
+            wallet=_strip_koinly_id(row_dict["From Wallet (read-only)"]),
+            note=row_dict["Description"],
+        )
+    else:
+        raise UnexpectedTypeError(parser.in_header.index("Type"), "Type", row_dict["Type"])
+
+
+DataParser(
+    ParserType.ACCOUNTING,
+    "Koinly",
+    [
+        "ID (read-only)",
+        "Parent ID (read-only)",
+        "Date (UTC)",
+        "Type",
+        "Tag",
+        "From Wallet (read-only)",
+        "From Wallet ID",
+        "From Amount",
+        "From Currency",
+        "To Wallet (read-only)",
+        "To Wallet ID",
+        "To Amount",
+        "To Currency",
+        "Fee Amount",
+        "Fee Currency",
+        "Net Worth Amount",
+        "Net Worth Currency",
+        "Fee Worth Amount",
+        "Fee Worth Currency",
+        "Net Value (read-only)",
+        "Fee Value (read-only)",
+        "Value Currency (read-only)",
+        "Deleted",
+        "From Source (read-only)",
+        "To Source (read-only)",
+        "Negative Balances (read-only)",
+        "Missing Rates (read-only)",
+        "Missing Cost Basis (read-only)",
+        "Synced To Accounting At (UTC read-only)",
+        "TxSrc",
+        "TxDest",
+        "TxHash",
+        "Description",
+    ],
+    worksheet_name="Koinly",
+    row_handler=parse_koinly_bulk_edit,
 )

--- a/tests/parsers/test_koinly.py
+++ b/tests/parsers/test_koinly.py
@@ -1,0 +1,163 @@
+from decimal import Decimal
+from typing import Dict, List
+
+from bittytax.bt_types import TrType
+from bittytax.config import config
+from bittytax.conv.dataparser import DataParser
+from bittytax.conv.datarow import DataRow
+from bittytax.conv.parsers.koinly import parse_koinly_bulk_edit
+
+config.ccy = "GBP"
+
+# Header of the Koinly "Bulk edit in Excel" transactions export. Currency and wallet cells carry
+# a ";<id>" suffix and the value is held in "Net Value (read-only)", see:
+# https://support.koinly.io/en/articles/9490043-bulk-edit-in-excel
+HEADER = [
+    "ID (read-only)",
+    "Parent ID (read-only)",
+    "Date (UTC)",
+    "Type",
+    "Tag",
+    "From Wallet (read-only)",
+    "From Wallet ID",
+    "From Amount",
+    "From Currency",
+    "To Wallet (read-only)",
+    "To Wallet ID",
+    "To Amount",
+    "To Currency",
+    "Fee Amount",
+    "Fee Currency",
+    "Net Worth Amount",
+    "Net Worth Currency",
+    "Fee Worth Amount",
+    "Fee Worth Currency",
+    "Net Value (read-only)",
+    "Fee Value (read-only)",
+    "Value Currency (read-only)",
+    "Deleted",
+    "From Source (read-only)",
+    "To Source (read-only)",
+    "Negative Balances (read-only)",
+    "Missing Rates (read-only)",
+    "Missing Cost Basis (read-only)",
+    "Synced To Accounting At (UTC read-only)",
+    "TxSrc",
+    "TxDest",
+    "TxHash",
+    "Description",
+]
+
+
+def _parse(**cells: str) -> DataRow:
+    parser = DataParser.match_header(HEADER, 0)
+    assert parser.row_handler is parse_koinly_bulk_edit
+
+    values: Dict[str, str] = {col: "" for col in HEADER}
+    values.update(cells)
+    row: List[str] = [values[col] for col in HEADER]
+
+    data_row = DataRow(1, row, parser.in_header, "Koinly")
+    parse_koinly_bulk_edit(data_row, parser)
+    return data_row
+
+
+def test_deposit_reward() -> None:
+    data_row = _parse(
+        **{
+            "Date (UTC)": "2025-01-03 22:19:40",
+            "Type": "deposit",
+            "Tag": "reward",
+            "To Wallet (read-only)": "Flare (FLR);flare",
+            "To Amount": "8121.9422723224",
+            "To Currency": "WFLR;9546698",
+            "Net Value (read-only)": "224.7162634542",
+            "Value Currency (read-only)": "GBP;1",
+        }
+    )
+    assert data_row.t_record is not None
+    assert data_row.t_record.t_type == TrType.STAKING_REWARD
+    assert data_row.t_record.buy_quantity == Decimal("8121.9422723224")
+    assert data_row.t_record.buy_asset == "WFLR"
+    assert data_row.t_record.buy_value == Decimal("224.7162634542")
+    assert data_row.t_record.wallet == "Flare (FLR)"
+
+
+def test_trade() -> None:
+    data_row = _parse(
+        **{
+            "Date (UTC)": "2025-02-01 10:00:00",
+            "Type": "trade",
+            "From Amount": "1",
+            "From Currency": "BTC;1",
+            "To Amount": "15",
+            "To Currency": "ETH;2",
+            "Net Value (read-only)": "50000",
+            "Value Currency (read-only)": "GBP",
+        }
+    )
+    assert data_row.t_record is not None
+    assert data_row.t_record.t_type == TrType.TRADE
+    assert data_row.t_record.buy_quantity == Decimal("15")
+    assert data_row.t_record.buy_asset == "ETH"
+    assert data_row.t_record.sell_quantity == Decimal("1")
+    assert data_row.t_record.sell_asset == "BTC"
+
+
+def test_withdrawal_cost() -> None:
+    data_row = _parse(
+        **{
+            "Date (UTC)": "2025-02-02 10:00:00",
+            "Type": "withdrawal",
+            "Tag": "Cost",
+            "From Amount": "0.5",
+            "From Currency": "ETH;2",
+        }
+    )
+    assert data_row.t_record is not None
+    assert data_row.t_record.t_type == TrType.SPEND
+    assert data_row.t_record.sell_quantity == Decimal("0.5")
+    assert data_row.t_record.sell_asset == "ETH"
+
+
+def test_untagged_deposit_is_transfer() -> None:
+    data_row = _parse(
+        **{
+            "Date (UTC)": "2025-02-05 10:00:00",
+            "Type": "deposit",
+            "To Amount": "2",
+            "To Currency": "ADA;5",
+        }
+    )
+    assert data_row.t_record is not None
+    assert data_row.t_record.t_type == TrType.DEPOSIT
+
+
+def test_unknown_tag_is_unmapped() -> None:
+    data_row = _parse(
+        **{
+            "Date (UTC)": "2025-02-07 10:00:00",
+            "Type": "deposit",
+            "Tag": "SomeTag",
+            "To Amount": "1",
+            "To Currency": "XYZ;9",
+        }
+    )
+    assert data_row.t_record is not None
+    assert data_row.t_record.t_type == "_SomeTag"
+
+
+def test_value_falls_back_to_net_worth() -> None:
+    data_row = _parse(
+        **{
+            "Date (UTC)": "2025-02-04 10:00:00",
+            "Type": "deposit",
+            "Tag": "reward",
+            "To Amount": "5",
+            "To Currency": "DOT;4",
+            "Net Worth Amount": "200",
+            "Net Worth Currency": "GBP",
+        }
+    )
+    assert data_row.t_record is not None
+    assert data_row.t_record.buy_value == Decimal("200")


### PR DESCRIPTION
## Summary

Adds a parser for Koinly's **"Bulk edit in Excel"** transactions export (Transactions → ⋮ → *Bulk edit in Excel* → *Export*):
https://support.koinly.io/en/articles/9490043-bulk-edit-in-excel

This is a different layout from the Koinly tax-report export already supported: one row per transaction with **From/To** columns (From Amount/Currency/Wallet, To Amount/Currency/Wallet) rather than Sent/Received columns, with the value held in a `Net Value (read-only)` column. It was previously unrecognised. The parser was built from a real 33-column export.

## Behaviour

- **Direction** is taken from the populated side: `To` only → deposit, `From` only → withdrawal, both → trade.
- The **Tag** column drives the type for deposits/withdrawals, reusing the existing `KOINLY_D_MAPPING` / `KOINLY_W_MAPPING`; an unrecognised tag becomes an `UnmappedType` for review, and an untagged transfer defaults to Deposit/Withdrawal.
- Currency and wallet cells carry a `;<id>` suffix (e.g. `WFLR;9546698`) which is stripped.
- The value is read from `Net Value (read-only)`, falling back to the user-set `Net Worth Amount`.
- The 33-column header is matched exactly (fixed header), consistent with the other parsers.

## Tests

`tests/parsers/test_koinly.py` covers deposit/reward, trade, withdrawal, untagged transfer, unknown tag, and the value fallback.
Also tested against a real export.